### PR TITLE
fix：AssistantParam and TextMessageParam fix some bug or some superior

### DIFF
--- a/src/main/java/com/alibaba/dashscope/assistants/AssistantParam.java
+++ b/src/main/java/com/alibaba/dashscope/assistants/AssistantParam.java
@@ -22,12 +22,14 @@ public class AssistantParam extends FlattenHalfDuplexParamBase {
   @NonNull private String model;
   @Default private String name = null;
   @Default private String description = null;
+
   /** Instructions */
   @SerializedName("instructions")
   @Default
   private String instructions = null;
 
   @Singular private List<ToolBase> tools;
+
   /**
    * File Ids
    *
@@ -55,7 +57,7 @@ public class AssistantParam extends FlattenHalfDuplexParamBase {
     if (instructions != null) {
       requestObject.addProperty("instructions", instructions);
     }
-    if (tools != null && !tools.isEmpty()) {
+    if (tools != null) {
       requestObject.add("tools", JsonUtils.toJsonArray(tools));
     }
     if (fileIds != null && !fileIds.isEmpty()) {

--- a/src/main/java/com/alibaba/dashscope/threads/messages/TextMessageParam.java
+++ b/src/main/java/com/alibaba/dashscope/threads/messages/TextMessageParam.java
@@ -47,7 +47,6 @@ public class TextMessageParam extends MessageParamBase {
   @Override
   public void validate() throws InputRequiredException {
     if (role.equals("")
-        || content.equals("")
         || !(role.equals("user") || role.equals("assistant"))) {
       throw new InputRequiredException("role mast be set and mast one of[user|assistant]");
     }


### PR DESCRIPTION
1.AssistantParam:allow user to remove assistant's tools，if the !tools.isEmpty() exists,the assistant always has a tools ,can't remove 2.TextMessageParam:first,the api allow user to send empty content message,second,if you want to validate the content not be empty,please check your exception message,the user doesn't know what happen if the role is right