### PR TITLE
Standardize Authorization header format: use 'Bearer' instead of 'bearer'

### DIFF
--- a/src/main/java/com/alibaba/dashscope/protocol/DashScopeHeaders.java
+++ b/src/main/java/com/alibaba/dashscope/protocol/DashScopeHeaders.java
@@ -24,7 +24,7 @@ public final class DashScopeHeaders {
       String apiKey, boolean isSecurityCheck, String workspace, Map<String, String> customHeaders)
       throws NoApiKeyException {
     Map<String, String> headers = new HashMap<>();
-    headers.put("Authorization", "bearer " + ApiKey.getApiKey(apiKey));
+    headers.put("Authorization", "Bearer " + ApiKey.getApiKey(apiKey));
     headers.put("user-agent", userAgent());
     if (workspace != null && !workspace.isEmpty()) {
       headers.put("X-DashScope-WorkSpace", workspace);


### PR DESCRIPTION
Fix Authorization header case sensitivity: use 'Bearer' instead of 'bearer'

Align WebSocket header format with HTTP request headers and RFC standards