### PR TITLE
Remove slf4j-simple dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>2.0.7</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
-        </dependency>
         <!-- dependent by okhttp-->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
             <artifactId>slf4j-api</artifactId>
             <version>2.0.7</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.7</version>
+            <scope>test</scope>
+        </dependency>
         <!-- dependent by okhttp-->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
Removed slf4j-simple dependency from pom.xml.
Libraries should only have a dependency on slf4j-api and not on slf4j-simple or any other specific logging binding (like logback-classic or log4j-core). This allows the application that uses your library to choose its own logging implementation, which is the main purpose of the SLF4J facade.