### PR TITLE
Add doc_url content type support in MessageAdapter (#123)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <name>DashScope Java SDK</name>
     <groupId>com.alibaba</groupId>
     <artifactId>dashscope-sdk-java</artifactId>
-    <version>2.22.21</version>
+    <version>2.22.22</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/com/alibaba/dashscope/Version.java
+++ b/src/main/java/com/alibaba/dashscope/Version.java
@@ -3,5 +3,5 @@
 package com.alibaba.dashscope;
 
 public final class Version {
-  public static final String version = "2.22.21";
+  public static final String version = "2.22.22";
 }

--- a/src/main/java/com/alibaba/dashscope/app/WorkflowMessage.java
+++ b/src/main/java/com/alibaba/dashscope/app/WorkflowMessage.java
@@ -27,9 +27,6 @@ public class WorkflowMessage {
   @SerializedName("message")
   private Message message;
 
-  @SerializedName("parent_node_id")
-  private String parentNodeId;
-
   @Data
   public static class Message {
     @SerializedName("role")

--- a/src/main/java/com/alibaba/dashscope/app/WorkflowMessage.java
+++ b/src/main/java/com/alibaba/dashscope/app/WorkflowMessage.java
@@ -27,6 +27,9 @@ public class WorkflowMessage {
   @SerializedName("message")
   private Message message;
 
+  @SerializedName("parent_node_id")
+  private String parentNodeId;
+
   @Data
   public static class Message {
     @SerializedName("role")

--- a/src/main/java/com/alibaba/dashscope/common/DocURL.java
+++ b/src/main/java/com/alibaba/dashscope/common/DocURL.java
@@ -1,0 +1,14 @@
+package com.alibaba.dashscope.common;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+public class DocURL {
+  private String url;
+
+  @SerializedName("file_parsing_strategy")
+  private String fileParsingStrategy;
+}

--- a/src/main/java/com/alibaba/dashscope/common/MessageAdapter.java
+++ b/src/main/java/com/alibaba/dashscope/common/MessageAdapter.java
@@ -67,20 +67,22 @@ public class MessageAdapter extends TypeAdapter<Message> {
           out.endObject();
           out.endObject(); // image url
         } else if (content.getType().equals(ApiKeywords.CONTENT_TYPE_DOC_URL)) {
-          out.beginObject();
-          out.name("type");
-          out.value(ApiKeywords.CONTENT_TYPE_DOC_URL);
-          out.name(ApiKeywords.CONTENT_TYPE_DOC_URL);
-          out.beginObject();
           DocURL docURL = ((MessageContentDocURL) content).getDocURL();
-          out.name("url");
-          out.value(docURL.getUrl());
-          if (docURL.getFileParsingStrategy() != null) {
-            out.name("file_parsing_strategy");
-            out.value(docURL.getFileParsingStrategy());
+          if (docURL != null) {
+            out.beginObject();
+            out.name("type");
+            out.value(ApiKeywords.CONTENT_TYPE_DOC_URL);
+            out.name(ApiKeywords.CONTENT_TYPE_DOC_URL);
+            out.beginObject();
+            out.name("url");
+            out.value(docURL.getUrl());
+            if (docURL.getFileParsingStrategy() != null) {
+              out.name("file_parsing_strategy");
+              out.value(docURL.getFileParsingStrategy());
+            }
+            out.endObject();
+            out.endObject();
           }
-          out.endObject();
-          out.endObject();
         }
       }
       out.endArray();
@@ -198,13 +200,17 @@ public class MessageAdapter extends TypeAdapter<Message> {
   private MessageContentDocURL parseDocContent(LinkedTreeMap<String, Object> contentItem) {
     LinkedTreeMap<String, Object> docUrlMap =
         (LinkedTreeMap<String, Object>) contentItem.get(ApiKeywords.CONTENT_TYPE_DOC_URL);
-    DocURL.DocURLBuilder docBuilder = DocURL.builder().url((String) docUrlMap.get("url"));
-    if (docUrlMap.containsKey("file_parsing_strategy")) {
-      docBuilder.fileParsingStrategy((String) docUrlMap.get("file_parsing_strategy"));
+    DocURL docURL = null;
+    if (docUrlMap != null) {
+      DocURL.DocURLBuilder docBuilder = DocURL.builder().url((String) docUrlMap.get("url"));
+      if (docUrlMap.containsKey("file_parsing_strategy")) {
+        docBuilder.fileParsingStrategy((String) docUrlMap.get("file_parsing_strategy"));
+      }
+      docURL = docBuilder.build();
     }
     return MessageContentDocURL.builder()
         .type((String) contentItem.get("type"))
-        .docURL(docBuilder.build())
+        .docURL(docURL)
         .build();
   }
 

--- a/src/main/java/com/alibaba/dashscope/common/MessageAdapter.java
+++ b/src/main/java/com/alibaba/dashscope/common/MessageAdapter.java
@@ -66,8 +66,22 @@ public class MessageAdapter extends TypeAdapter<Message> {
           }
           out.endObject();
           out.endObject(); // image url
+        } else if (content.getType().equals(ApiKeywords.CONTENT_TYPE_DOC_URL)) {
+          out.beginObject();
+          out.name("type");
+          out.value(ApiKeywords.CONTENT_TYPE_DOC_URL);
+          out.name(ApiKeywords.CONTENT_TYPE_DOC_URL);
+          out.beginObject();
+          DocURL docURL = ((MessageContentDocURL) content).getDocURL();
+          out.name("url");
+          out.value(docURL.getUrl());
+          if (docURL.getFileParsingStrategy() != null) {
+            out.name("file_parsing_strategy");
+            out.value(docURL.getFileParsingStrategy());
+          }
+          out.endObject();
+          out.endObject();
         }
-        // not support type, TODO extends types.
       }
       out.endArray();
     }
@@ -129,6 +143,8 @@ public class MessageAdapter extends TypeAdapter<Message> {
         contents.add(parseTextContent(contentItem));
       } else if (ApiKeywords.CONTENT_TYPE_IMAGE_URL.equals(type)) {
         contents.add(parseImageContent(contentItem));
+      } else if (ApiKeywords.CONTENT_TYPE_DOC_URL.equals(type)) {
+        contents.add(parseDocContent(contentItem));
       }
     }
     return contents;
@@ -174,6 +190,21 @@ public class MessageAdapter extends TypeAdapter<Message> {
     return MessageContentImageURL.builder()
         .type((String) contentItem.get("type"))
         .imageURL(imageBuilder.build())
+        .build();
+  }
+
+  // Parse doc_url content
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private MessageContentDocURL parseDocContent(LinkedTreeMap<String, Object> contentItem) {
+    LinkedTreeMap<String, Object> docUrlMap =
+        (LinkedTreeMap<String, Object>) contentItem.get(ApiKeywords.CONTENT_TYPE_DOC_URL);
+    DocURL.DocURLBuilder docBuilder = DocURL.builder().url((String) docUrlMap.get("url"));
+    if (docUrlMap.containsKey("file_parsing_strategy")) {
+      docBuilder.fileParsingStrategy((String) docUrlMap.get("file_parsing_strategy"));
+    }
+    return MessageContentDocURL.builder()
+        .type((String) contentItem.get("type"))
+        .docURL(docBuilder.build())
         .build();
   }
 

--- a/src/main/java/com/alibaba/dashscope/common/MessageContentDocURL.java
+++ b/src/main/java/com/alibaba/dashscope/common/MessageContentDocURL.java
@@ -1,0 +1,17 @@
+package com.alibaba.dashscope.common;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class MessageContentDocURL extends MessageContentBase {
+  @Builder.Default private String type = "doc_url";
+
+  @SerializedName("doc_url")
+  private DocURL docURL;
+}

--- a/src/main/java/com/alibaba/dashscope/utils/ApiKeywords.java
+++ b/src/main/java/com/alibaba/dashscope/utils/ApiKeywords.java
@@ -117,6 +117,8 @@ public class ApiKeywords {
 
   public static final String CONTENT_TYPE_IMAGE_URL = "image_url";
 
+  public static final String CONTENT_TYPE_DOC_URL = "doc_url";
+
   public static final String CONTENT_TYPE_CACHE_CONTROL = "cache_control";
 
   public static final String RESOURCE_ID = "resource_id";


### PR DESCRIPTION
## Summary
- Fixes #123
- Add `doc_url` content type support in `MessageAdapter` for document URL parsing
- New classes: `DocURL`, `MessageContentDocURL`
- Add `CONTENT_TYPE_DOC_URL` constant to `ApiKeywords`

## Test plan
- [x] Unit tests pass (111 tests, 0 failures)
- [x] Lint passes (google-java-format)