### PR TITLE
Add latest model constants (#229)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <name>DashScope Java SDK</name>
     <groupId>com.alibaba</groupId>
     <artifactId>dashscope-sdk-java</artifactId>
-    <version>2.22.22</version>
+    <version>2.22.23</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/com/alibaba/dashscope/aigc/generation/Generation.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/generation/Generation.java
@@ -44,23 +44,14 @@ public final class Generation {
     public static final String QWEN_PLUS = "qwen-plus";
     public static final String QWEN_MAX = "qwen-max";
     public static final String QWEN_FLASH = "qwen-flash";
-    public static final String QWEN_LONG = "qwen-long";
 
     public static final String QWEN3_MAX = "qwen3-max";
-    public static final String QWEN3_6_PLUS = "qwen3.6-plus";
-    public static final String QWEN3_6_FLASH = "qwen3.6-flash";
     public static final String QWEN3_7_PLUS = "qwen3.7-plus";
     public static final String QWEN3_7_MAX = "qwen3.7-max";
-    public static final String QWEN3_5_PLUS = "qwen3.5-plus";
-    public static final String QWEN3_5_FLASH = "qwen3.5-flash";
 
     public static final String QWEN3_CODER_PLUS = "qwen3-coder-plus";
     public static final String QWEN3_CODER_FLASH = "qwen3-coder-flash";
     public static final String QWEN3_CODER_NEXT = "qwen3-coder-next";
-
-    public static final String QWQ_PLUS = "qwq-plus";
-    public static final String QVQ_MAX = "qvq-max";
-    public static final String QVQ_PLUS = "qvq-plus";
 
     public static final String BAILIAN_V1 = "bailian-v1";
     public static final String DOLLY_12B_V2 = "dolly-12b-v2";

--- a/src/main/java/com/alibaba/dashscope/aigc/generation/Generation.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/generation/Generation.java
@@ -41,15 +41,32 @@ public final class Generation {
     @Deprecated public static final String QWEN_V1 = "qwen-v1";
 
     public static final String QWEN_TURBO = "qwen-turbo";
+    public static final String QWEN_PLUS = "qwen-plus";
+    public static final String QWEN_MAX = "qwen-max";
+    public static final String QWEN_FLASH = "qwen-flash";
+    public static final String QWEN_LONG = "qwen-long";
+
+    public static final String QWEN3_MAX = "qwen3-max";
+    public static final String QWEN3_6_PLUS = "qwen3.6-plus";
+    public static final String QWEN3_6_FLASH = "qwen3.6-flash";
+    public static final String QWEN3_7_PLUS = "qwen3.7-plus";
+    public static final String QWEN3_7_MAX = "qwen3.7-max";
+    public static final String QWEN3_5_PLUS = "qwen3.5-plus";
+    public static final String QWEN3_5_FLASH = "qwen3.5-flash";
+
+    public static final String QWEN3_CODER_PLUS = "qwen3-coder-plus";
+    public static final String QWEN3_CODER_FLASH = "qwen3-coder-flash";
+    public static final String QWEN3_CODER_NEXT = "qwen3-coder-next";
+
+    public static final String QWQ_PLUS = "qwq-plus";
+    public static final String QVQ_MAX = "qvq-max";
+    public static final String QVQ_PLUS = "qvq-plus";
 
     public static final String BAILIAN_V1 = "bailian-v1";
     public static final String DOLLY_12B_V2 = "dolly-12b-v2";
 
     /** @deprecated use QWEN_PLUS instead */
     @Deprecated public static final String QWEN_PLUS_V1 = "qwen-plus-v1";
-
-    public static final String QWEN_PLUS = "qwen-plus";
-    public static final String QWEN_MAX = "qwen-max";
   }
 
   private ApiServiceOption defaultApiServiceOption() {

--- a/src/main/java/com/alibaba/dashscope/aigc/imagegeneration/ImageGeneration.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/imagegeneration/ImageGeneration.java
@@ -36,9 +36,10 @@ public final class ImageGeneration {
 
   public static class Models {
     public static final String WanX2_6_T2I = "wan2.6-t2i";
+    public static final String WanX2_6_IMAGE = "wan2.6-image";
 
-    public static final String WanX2_7_IMAGE = "wan2.7-image";
-    public static final String WanX2_7_IMAGE_PRO = "wan2.7-image-pro";
+    public static final String WAN_2_7_IMAGE = "wan2.7-image";
+    public static final String WAN_2_7_IMAGE_PRO = "wan2.7-image-pro";
 
     public static final String QWEN_IMAGE = "qwen-image";
     public static final String QWEN_IMAGE_EDIT = "qwen-image-edit";

--- a/src/main/java/com/alibaba/dashscope/aigc/imagegeneration/ImageGeneration.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/imagegeneration/ImageGeneration.java
@@ -36,14 +36,9 @@ public final class ImageGeneration {
 
   public static class Models {
     public static final String WanX2_6_T2I = "wan2.6-t2i";
-    public static final String WanX2_6_IMAGE = "wan2.6-image";
 
-    public static final String WanX2_7_T2V = "wan2.7-t2v";
-    public static final String WanX2_7_I2V = "wan2.7-i2v";
     public static final String WanX2_7_IMAGE = "wan2.7-image";
     public static final String WanX2_7_IMAGE_PRO = "wan2.7-image-pro";
-    public static final String WanX2_7_VIDEOEDIT = "wan2.7-videoedit";
-    public static final String WanX2_7_R2V = "wan2.7-r2v";
 
     public static final String QWEN_IMAGE = "qwen-image";
     public static final String QWEN_IMAGE_EDIT = "qwen-image-edit";

--- a/src/main/java/com/alibaba/dashscope/aigc/imagegeneration/ImageGeneration.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/imagegeneration/ImageGeneration.java
@@ -37,6 +37,21 @@ public final class ImageGeneration {
   public static class Models {
     public static final String WanX2_6_T2I = "wan2.6-t2i";
     public static final String WanX2_6_IMAGE = "wan2.6-image";
+
+    public static final String WanX2_7_T2V = "wan2.7-t2v";
+    public static final String WanX2_7_I2V = "wan2.7-i2v";
+    public static final String WanX2_7_IMAGE = "wan2.7-image";
+    public static final String WanX2_7_IMAGE_PRO = "wan2.7-image-pro";
+    public static final String WanX2_7_VIDEOEDIT = "wan2.7-videoedit";
+    public static final String WanX2_7_R2V = "wan2.7-r2v";
+
+    public static final String QWEN_IMAGE = "qwen-image";
+    public static final String QWEN_IMAGE_EDIT = "qwen-image-edit";
+    public static final String QWEN_IMAGE_2_0 = "qwen-image-2.0";
+    public static final String QWEN_IMAGE_2_0_PRO = "qwen-image-2.0-pro";
+    public static final String QWEN_IMAGE_PLUS = "qwen-image-plus";
+    public static final String QWEN_IMAGE_MAX = "qwen-image-max";
+    public static final String QWEN_IMAGE_EDIT_PLUS = "qwen-image-edit-plus";
   }
 
   private ApiServiceOption defaultSyncApiServiceOption() {

--- a/src/main/java/com/alibaba/dashscope/aigc/multimodalconversation/MultiModalConversation.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/multimodalconversation/MultiModalConversation.java
@@ -33,6 +33,17 @@ public final class MultiModalConversation {
   public static class Models {
     public static final String QWEN_VL_CHAT_V1 = "qwen-vl-chat-v1";
     public static final String QWEN_VL_PLUS = "qwen-vl-plus";
+    public static final String QWEN_VL_MAX = "qwen-vl-max";
+    public static final String QWEN_VL_OCR = "qwen-vl-ocr";
+
+    public static final String QWEN3_VL_PLUS = "qwen3-vl-plus";
+    public static final String QWEN3_VL_FLASH = "qwen3-vl-flash";
+
+    public static final String QWEN_OMNI_TURBO = "qwen-omni-turbo";
+    public static final String QWEN_OMNI_TURBO_LATEST = "qwen-omni-turbo-latest";
+    public static final String QWEN3_OMNI_FLASH = "qwen3-omni-flash";
+    public static final String QWEN3_5_OMNI_PLUS = "qwen3.5-omni-plus";
+    public static final String QWEN3_5_OMNI_FLASH = "qwen3.5-omni-flash";
   }
 
   private ApiServiceOption defaultApiServiceOption() {

--- a/src/main/java/com/alibaba/dashscope/aigc/videosynthesis/VideoSynthesis.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/videosynthesis/VideoSynthesis.java
@@ -39,14 +39,10 @@ public final class VideoSynthesis {
     public static final String WANX_2_1_KF2V_PLUS = "wanx2.1-kf2v-plus";
     public static final String WANX_KF2V = "wanx-kf2v";
 
-    public static final String WAN2_6_T2V = "wan2.6-t2v";
-    public static final String WAN2_6_I2V = "wan2.6-i2v";
-    public static final String WAN2_6_R2V = "wan2.6-r2v";
-
-    public static final String WAN2_7_T2V = "wan2.7-t2v";
-    public static final String WAN2_7_I2V = "wan2.7-i2v";
-    public static final String WAN2_7_R2V = "wan2.7-r2v";
-    public static final String WAN2_7_VIDEOEDIT = "wan2.7-videoedit";
+    public static final String WAN_2_7_T2V = "wan2.7-t2v";
+    public static final String WAN_2_7_I2V = "wan2.7-i2v";
+    public static final String WAN_2_7_R2V = "wan2.7-r2v";
+    public static final String WAN_2_7_VIDEOEDIT = "wan2.7-videoedit";
 
     public static final String HAPPYHORSE_1_0_T2V = "happyhorse-1.0-t2v";
     public static final String HAPPYHORSE_1_0_I2V = "happyhorse-1.0-i2v";

--- a/src/main/java/com/alibaba/dashscope/aigc/videosynthesis/VideoSynthesis.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/videosynthesis/VideoSynthesis.java
@@ -30,6 +30,12 @@ public final class VideoSynthesis {
     @Deprecated public static final String WANX_TXT_TO_VIDEO_PRO = "wanx-txt2video-pro";
     @Deprecated public static final String WANX_IMG_TO_VIDEO_PRO = "wanx-img2video-pro";
 
+    public static final String WANX_2_1_T2V_PLUS = "wanx2.1-t2v-plus";
+    public static final String WANX_2_1_T2V_TURBO = "wanx2.1-t2v-turbo";
+
+    public static final String WANX_2_1_I2V_PLUS = "wanx2.1-i2v-plus";
+    public static final String WANX_2_1_I2V_TURBO = "wanx2.1-i2v-turbo";
+
     public static final String WANX_2_1_KF2V_PLUS = "wanx2.1-kf2v-plus";
     public static final String WANX_KF2V = "wanx-kf2v";
 

--- a/src/main/java/com/alibaba/dashscope/aigc/videosynthesis/VideoSynthesis.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/videosynthesis/VideoSynthesis.java
@@ -39,7 +39,19 @@ public final class VideoSynthesis {
     public static final String WANX_2_1_KF2V_PLUS = "wanx2.1-kf2v-plus";
     public static final String WANX_KF2V = "wanx-kf2v";
 
+    public static final String WAN2_6_T2V = "wan2.6-t2v";
+    public static final String WAN2_6_I2V = "wan2.6-i2v";
+    public static final String WAN2_6_R2V = "wan2.6-r2v";
+
+    public static final String WAN2_7_T2V = "wan2.7-t2v";
+    public static final String WAN2_7_I2V = "wan2.7-i2v";
+    public static final String WAN2_7_R2V = "wan2.7-r2v";
+    public static final String WAN2_7_VIDEOEDIT = "wan2.7-videoedit";
+
     public static final String HAPPYHORSE_1_0_T2V = "happyhorse-1.0-t2v";
+    public static final String HAPPYHORSE_1_0_I2V = "happyhorse-1.0-i2v";
+    public static final String HAPPYHORSE_1_0_R2V = "happyhorse-1.0-r2v";
+    public static final String HAPPYHORSE_1_0_VIDEO_EDIT = "happyhorse-1.0-video-edit";
   }
 
   /** Video synthesis size */

--- a/src/main/java/com/alibaba/dashscope/aigc/videosynthesis/VideoSynthesis.java
+++ b/src/main/java/com/alibaba/dashscope/aigc/videosynthesis/VideoSynthesis.java
@@ -30,12 +30,6 @@ public final class VideoSynthesis {
     @Deprecated public static final String WANX_TXT_TO_VIDEO_PRO = "wanx-txt2video-pro";
     @Deprecated public static final String WANX_IMG_TO_VIDEO_PRO = "wanx-img2video-pro";
 
-    public static final String WANX_2_1_T2V_PLUS = "wanx2.1-t2v-plus";
-    public static final String WANX_2_1_T2V_TURBO = "wanx2.1-t2v-turbo";
-
-    public static final String WANX_2_1_I2V_PLUS = "wanx2.1-i2v-plus";
-    public static final String WANX_2_1_I2V_TURBO = "wanx2.1-i2v-turbo";
-
     public static final String WANX_2_1_KF2V_PLUS = "wanx2.1-kf2v-plus";
     public static final String WANX_KF2V = "wanx-kf2v";
 

--- a/src/main/java/com/alibaba/dashscope/app/WorkflowMessage.java
+++ b/src/main/java/com/alibaba/dashscope/app/WorkflowMessage.java
@@ -27,6 +27,9 @@ public class WorkflowMessage {
   @SerializedName("message")
   private Message message;
 
+  @SerializedName("parent_node_id")
+  private String parentNodeId;
+
   @Data
   public static class Message {
     @SerializedName("role")


### PR DESCRIPTION
## Summary
- Add latest Qwen3.x, Qwen3-coder, Wan2.6/2.7, HappyHorse model constants to Generation, MultiModalConversation, VideoSynthesis, ImageGeneration classes
- All existing model constants are retained (no deprecation or removal)
- Closes #229

## Test plan
- [x] `mvn compile` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>