### PR TITLE
deprecate: mark Threads, Messages, and Runs classes as deprecated

### DIFF
--- a/src/main/java/com/alibaba/dashscope/threads/Threads.java
+++ b/src/main/java/com/alibaba/dashscope/threads/Threads.java
@@ -18,9 +18,10 @@ import com.alibaba.dashscope.protocol.StreamingMode;
 import com.alibaba.dashscope.utils.StringUtils;
 
 /**
- * @deprecated The threads API is deprecated and will be removed in a future version.
- *             Please use the Responses API instead.
- *             See <a href="https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference">Responses API documentation</a>
+ * @deprecated The threads API is deprecated and will be removed in a future version. Please use the
+ *     Responses API instead. See <a
+ *     href="https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference">Responses API
+ *     documentation</a>
  */
 @Deprecated
 public final class Threads {

--- a/src/main/java/com/alibaba/dashscope/threads/Threads.java
+++ b/src/main/java/com/alibaba/dashscope/threads/Threads.java
@@ -17,6 +17,12 @@ import com.alibaba.dashscope.protocol.Protocol;
 import com.alibaba.dashscope.protocol.StreamingMode;
 import com.alibaba.dashscope.utils.StringUtils;
 
+/**
+ * @deprecated The threads API is deprecated and will be removed in a future version.
+ *             Please use the Responses API instead.
+ *             See <a href="https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference">Responses API documentation</a>
+ */
+@Deprecated
 public final class Threads {
   private final GeneralApi<HalfDuplexParamBase> api;
   private final GeneralServiceOption serviceOption;

--- a/src/main/java/com/alibaba/dashscope/threads/messages/Messages.java
+++ b/src/main/java/com/alibaba/dashscope/threads/messages/Messages.java
@@ -23,9 +23,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @deprecated The messages API is deprecated and will be removed in a future version.
- *             Please use the Responses API instead.
- *             See <a href="https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference">Responses API documentation</a>
+ * @deprecated The messages API is deprecated and will be removed in a future version. Please use
+ *     the Responses API instead. See <a
+ *     href="https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference">Responses API
+ *     documentation</a>
  */
 @Deprecated
 public final class Messages {

--- a/src/main/java/com/alibaba/dashscope/threads/messages/Messages.java
+++ b/src/main/java/com/alibaba/dashscope/threads/messages/Messages.java
@@ -22,6 +22,12 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @deprecated The messages API is deprecated and will be removed in a future version.
+ *             Please use the Responses API instead.
+ *             See <a href="https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference">Responses API documentation</a>
+ */
+@Deprecated
 public final class Messages {
   private final GeneralApi<HalfDuplexParamBase> api;
   private final GeneralServiceOption serviceOption;

--- a/src/main/java/com/alibaba/dashscope/threads/runs/Runs.java
+++ b/src/main/java/com/alibaba/dashscope/threads/runs/Runs.java
@@ -25,9 +25,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @deprecated The runs API is deprecated and will be removed in a future version.
- *             Please use the Responses API instead.
- *             See <a href="https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference">Responses API documentation</a>
+ * @deprecated The runs API is deprecated and will be removed in a future version. Please use the
+ *     Responses API instead. See <a
+ *     href="https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference">Responses API
+ *     documentation</a>
  */
 @Deprecated
 public final class Runs {

--- a/src/main/java/com/alibaba/dashscope/threads/runs/Runs.java
+++ b/src/main/java/com/alibaba/dashscope/threads/runs/Runs.java
@@ -24,6 +24,12 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @deprecated The runs API is deprecated and will be removed in a future version.
+ *             Please use the Responses API instead.
+ *             See <a href="https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference">Responses API documentation</a>
+ */
+@Deprecated
 public final class Runs {
   private final GeneralApi<HalfDuplexParamBase> api;
   private final GeneralServiceOption serviceOption;


### PR DESCRIPTION
Add @Deprecated annotation and Javadoc to thread-related classes to guide users toward the new Responses API.

- Threads.java: deprecated with migration guidance
- Messages.java: deprecated with migration guidance
- Runs.java: deprecated with migration guidance

All classes now include:
- @deprecated Javadoc tag explaining deprecation
- Link to Responses API documentation
- @Deprecated annotation for IDE warnings

Reference: https://help.aliyun.com/zh/model-studio/synchronous-call-api-reference