### PR TITLE
feat(agentstudio): add managed agent deployment APIs

### DIFF
--- a/samples/AgentStudioDeployments.java
+++ b/samples/AgentStudioDeployments.java
@@ -1,0 +1,52 @@
+import com.alibaba.dashscope.agentstudio.AgentStudioClient;
+import com.alibaba.dashscope.agentstudio.message.ClientEvents;
+import com.alibaba.dashscope.agentstudio.model.Deployment;
+import com.alibaba.dashscope.agentstudio.model.DeploymentRun;
+import com.alibaba.dashscope.agentstudio.param.DeploymentAgentParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentCreateParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentRunListParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentScheduleParam;
+import java.util.Collections;
+
+/**
+ * Managed Agent deployment example.
+ *
+ * <p>Set DASHSCOPE_API_KEY and DASHSCOPE_WORKSPACE before running.
+ */
+public class AgentStudioDeployments {
+
+  public static void main(String[] args) {
+    try (AgentStudioClient client = new AgentStudioClient()) {
+      Deployment deployment =
+          client
+              .deployments()
+              .create(
+                  DeploymentCreateParam.builder()
+                      .name("daily-summary")
+                      .description("Generate a daily summary")
+                      .agent(DeploymentAgentParam.builder().id("agent_xxx").build())
+                      .schedule(
+                          DeploymentScheduleParam.builder()
+                              .type(DeploymentScheduleParam.TYPE_CRON)
+                              .expression("0 9 * * 1-5")
+                              .timezone("Asia/Shanghai")
+                              .build())
+                      .initialEvents(
+                          Collections.singletonList(
+                              ClientEvents.userMessage("Summarize yesterday's orders")))
+                      .metadata(Collections.singletonMap("biz", "summary"))
+                      .build());
+      System.out.printf("deployment: %s %s%n", deployment.getId(), deployment.getStatus());
+
+      DeploymentRun run = client.deployments().run(deployment.getId());
+      System.out.printf("run: %s %s%n", run.getId(), run.getStatus());
+
+      for (DeploymentRun item :
+          client
+              .deployments()
+              .listRuns(deployment.getId(), DeploymentRunListParam.builder().limit(20).build())) {
+        System.out.printf("%s %s %s%n", item.getId(), item.getTriggerSource(), item.getStatus());
+      }
+    }
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/AgentStudioClient.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/AgentStudioClient.java
@@ -2,6 +2,8 @@
 package com.alibaba.dashscope.agentstudio;
 
 import com.alibaba.dashscope.agentstudio.resource.Agents;
+import com.alibaba.dashscope.agentstudio.resource.DeploymentRuns;
+import com.alibaba.dashscope.agentstudio.resource.Deployments;
 import com.alibaba.dashscope.agentstudio.resource.Environments;
 import com.alibaba.dashscope.agentstudio.resource.Files;
 import com.alibaba.dashscope.agentstudio.resource.Sessions;
@@ -14,6 +16,8 @@ import java.util.function.Supplier;
 
 public class AgentStudioClient implements Closeable {
   private final Agents agents;
+  private final Deployments deployments;
+  private final DeploymentRuns deploymentRuns;
   private final Sessions sessions;
   private final Environments environments;
   private final Skills skills;
@@ -41,6 +45,8 @@ public class AgentStudioClient implements Closeable {
       ConnectionOptions connectionOptions) {
     this.baseUrl = resolveBaseUrl(baseUrl, workspace, region);
     this.agents = new Agents(this.baseUrl, connectionOptions, apiKey);
+    this.deployments = new Deployments(this.baseUrl, connectionOptions, apiKey);
+    this.deploymentRuns = new DeploymentRuns(this.baseUrl, connectionOptions, apiKey);
     this.sessions = new Sessions(this.baseUrl, connectionOptions, apiKey);
     this.environments = new Environments(this.baseUrl, connectionOptions, apiKey);
     this.files = new Files(this.baseUrl, connectionOptions, apiKey);
@@ -91,6 +97,14 @@ public class AgentStudioClient implements Closeable {
 
   public Agents agents() {
     return agents;
+  }
+
+  public Deployments deployments() {
+    return deployments;
+  }
+
+  public DeploymentRuns deploymentRuns() {
+    return deploymentRuns;
   }
 
   public Sessions sessions() {

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/Deployment.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/Deployment.java
@@ -1,0 +1,62 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.alibaba.dashscope.agentstudio.message.Message;
+import com.alibaba.dashscope.common.FlattenResultBase;
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class Deployment extends FlattenResultBase {
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("type")
+  private String type;
+
+  @SerializedName("name")
+  private String name;
+
+  @SerializedName("description")
+  private String description;
+
+  @SerializedName("agent")
+  private Agent agent;
+
+  @SerializedName("environment_id")
+  private String environmentId;
+
+  @SerializedName("schedule")
+  private DeploymentSchedule schedule;
+
+  @SerializedName("initial_events")
+  private List<Message> initialEvents;
+
+  @SerializedName("resources")
+  private List<DeploymentResource> resources;
+
+  @SerializedName("vault_ids")
+  private List<String> vaultIds;
+
+  @SerializedName("metadata")
+  private Map<String, Object> metadata;
+
+  @SerializedName("status")
+  private String status;
+
+  @SerializedName("paused_reason")
+  private DeploymentPausedReason pausedReason;
+
+  @SerializedName("archived_at")
+  private String archivedAt;
+
+  @SerializedName("created_at")
+  private String createdAt;
+
+  @SerializedName("updated_at")
+  private String updatedAt;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/Deployment.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/Deployment.java
@@ -43,7 +43,7 @@ public class Deployment extends FlattenResultBase {
   private List<String> vaultIds;
 
   @SerializedName("metadata")
-  private Map<String, Object> metadata;
+  private Map<String, String> metadata;
 
   @SerializedName("status")
   private String status;

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentAgentReference.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentAgentReference.java
@@ -1,0 +1,14 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class DeploymentAgentReference {
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("version")
+  private Integer version;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentError.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentError.java
@@ -1,0 +1,14 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class DeploymentError {
+  @SerializedName("code")
+  private String code;
+
+  @SerializedName("message")
+  private String message;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentPausedReason.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentPausedReason.java
@@ -1,0 +1,14 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class DeploymentPausedReason {
+  @SerializedName("type")
+  private String type;
+
+  @SerializedName("error")
+  private DeploymentError error;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentResource.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentResource.java
@@ -1,0 +1,17 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class DeploymentResource {
+  @SerializedName("type")
+  private String type;
+
+  @SerializedName("file_id")
+  private String fileId;
+
+  @SerializedName("mount_path")
+  private String mountPath;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentRun.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentRun.java
@@ -1,0 +1,41 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.alibaba.dashscope.common.FlattenResultBase;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class DeploymentRun extends FlattenResultBase {
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("type")
+  private String type;
+
+  @SerializedName("deployment_id")
+  private String deploymentId;
+
+  @SerializedName("agent")
+  private DeploymentAgentReference agent;
+
+  @SerializedName("session_id")
+  private String sessionId;
+
+  @SerializedName("trigger_source")
+  private String triggerSource;
+
+  @SerializedName("status")
+  private String status;
+
+  @SerializedName("error")
+  private DeploymentError error;
+
+  @SerializedName("started_at")
+  private String startedAt;
+
+  @SerializedName("finished_at")
+  private String finishedAt;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentSchedule.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/DeploymentSchedule.java
@@ -1,0 +1,23 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class DeploymentSchedule {
+  @SerializedName("type")
+  private String type;
+
+  @SerializedName("expression")
+  private String expression;
+
+  @SerializedName("timezone")
+  private String timezone;
+
+  @SerializedName("last_run_at")
+  private String lastRunAt;
+
+  @SerializedName("next_run_at")
+  private String nextRunAt;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentAgentParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentAgentParam.java
@@ -1,0 +1,18 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+@Builder
+public class DeploymentAgentParam {
+  @NonNull
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("version")
+  private Integer version;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
@@ -26,7 +26,7 @@ public class DeploymentCreateParam extends FlattenHalfDuplexParamBase {
   @NonNull private List<JsonObject> initialEvents;
   @Default private List<DeploymentResourceParam> resources = null;
   @Default private List<String> vaultIds = null;
-  @Default private Map<String, Object> metadata = null;
+  @Default private Map<String, String> metadata = null;
 
   @Override
   public JsonObject getHttpBody() {

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
@@ -5,6 +5,7 @@ import com.alibaba.dashscope.base.FlattenHalfDuplexParamBase;
 import com.alibaba.dashscope.utils.JsonUtils;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder.Default;
@@ -61,7 +62,7 @@ public class DeploymentCreateParam extends FlattenHalfDuplexParamBase {
       body.add("vault_ids", vaultItems);
     }
     if (metadata != null) {
-      body.add("metadata", JsonUtils.toJsonElement(metadata));
+      body.add("metadata", JsonUtils.toJsonElement(new LinkedHashMap<>(metadata)));
     }
     addExtraBody(body);
     return body;

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
@@ -1,0 +1,69 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.alibaba.dashscope.base.FlattenHalfDuplexParamBase;
+import com.alibaba.dashscope.utils.JsonUtils;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class DeploymentCreateParam extends FlattenHalfDuplexParamBase {
+  @NonNull private String name;
+  @Default private String description = null;
+  @NonNull private DeploymentAgentParam agent;
+  @Default private String environmentId = null;
+  @Default private DeploymentScheduleParam schedule = null;
+  @NonNull private List<JsonObject> initialEvents;
+  @Default private List<DeploymentResourceParam> resources = null;
+  @Default private List<String> vaultIds = null;
+  @Default private Map<String, Object> metadata = null;
+
+  @Override
+  public JsonObject getHttpBody() {
+    JsonObject body = new JsonObject();
+    body.addProperty("name", name);
+    if (description != null) {
+      body.addProperty("description", description);
+    }
+    body.add("agent", JsonUtils.toJsonElement(agent));
+    if (environmentId != null) {
+      body.addProperty("environment_id", environmentId);
+    }
+    if (schedule != null) {
+      body.add("schedule", JsonUtils.toJsonElement(schedule));
+    }
+    JsonArray events = new JsonArray();
+    for (JsonObject event : initialEvents) {
+      events.add(event);
+    }
+    body.add("initial_events", events);
+    if (resources != null) {
+      JsonArray resourceItems = new JsonArray();
+      for (DeploymentResourceParam resource : resources) {
+        resourceItems.add(JsonUtils.toJsonElement(resource));
+      }
+      body.add("resources", resourceItems);
+    }
+    if (vaultIds != null) {
+      JsonArray vaultItems = new JsonArray();
+      for (String vaultId : vaultIds) {
+        vaultItems.add(vaultId);
+      }
+      body.add("vault_ids", vaultItems);
+    }
+    if (metadata != null) {
+      body.add("metadata", JsonUtils.toJsonElement(metadata));
+    }
+    addExtraBody(body);
+    return body;
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentListParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentListParam.java
@@ -1,0 +1,42 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.alibaba.dashscope.agentstudio.AgentStudioConstants;
+import com.alibaba.dashscope.base.FlattenHalfDuplexParamBase;
+import com.google.gson.JsonObject;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class DeploymentListParam extends FlattenHalfDuplexParamBase {
+  @Default private String agentId = null;
+  @Default private String keyword = null;
+  @Default private String status = null;
+  @Default private Boolean includeArchived = null;
+  @Default private Integer limit = null;
+  @Default private String page = null;
+  @Default private String createdAtGte = null;
+  @Default private String createdAtLte = null;
+
+  @Override
+  public JsonObject getHttpBody() {
+    return new JsonObject();
+  }
+
+  public String toQueryString() {
+    StringBuilder sb = new StringBuilder();
+    AgentStudioConstants.appendParam(sb, "agent_id", agentId);
+    AgentStudioConstants.appendParam(sb, "keyword", keyword);
+    AgentStudioConstants.appendParam(sb, "status", status);
+    AgentStudioConstants.appendParam(sb, "include_archived", includeArchived);
+    AgentStudioConstants.appendParam(sb, "limit", limit);
+    AgentStudioConstants.appendParam(sb, "page", page);
+    AgentStudioConstants.appendParam(sb, "created_at[gte]", createdAtGte);
+    AgentStudioConstants.appendParam(sb, "created_at[lte]", createdAtLte);
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentResourceParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentResourceParam.java
@@ -1,0 +1,25 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+@Builder
+public class DeploymentResourceParam {
+  public static final String TYPE_FILE = "file";
+
+  @NonNull
+  @SerializedName("type")
+  private String type;
+
+  @NonNull
+  @SerializedName("file_id")
+  private String fileId;
+
+  @NonNull
+  @SerializedName("mount_path")
+  private String mountPath;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentRunListParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentRunListParam.java
@@ -1,0 +1,30 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.alibaba.dashscope.agentstudio.AgentStudioConstants;
+import com.alibaba.dashscope.base.FlattenHalfDuplexParamBase;
+import com.google.gson.JsonObject;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class DeploymentRunListParam extends FlattenHalfDuplexParamBase {
+  @Default private Integer limit = null;
+  @Default private String page = null;
+
+  @Override
+  public JsonObject getHttpBody() {
+    return new JsonObject();
+  }
+
+  public String toQueryString() {
+    StringBuilder sb = new StringBuilder();
+    AgentStudioConstants.appendParam(sb, "limit", limit);
+    AgentStudioConstants.appendParam(sb, "page", page);
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentScheduleParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentScheduleParam.java
@@ -1,0 +1,25 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+@Builder
+public class DeploymentScheduleParam {
+  public static final String TYPE_CRON = "cron";
+
+  @NonNull
+  @SerializedName("type")
+  private String type;
+
+  @NonNull
+  @SerializedName("expression")
+  private String expression;
+
+  @NonNull
+  @SerializedName("timezone")
+  private String timezone;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
@@ -6,6 +6,7 @@ import com.alibaba.dashscope.utils.JsonUtils;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder.Default;
@@ -84,7 +85,7 @@ public class DeploymentUpdateParam extends FlattenHalfDuplexParamBase {
       body.add("vault_ids", vaultItems);
     }
     if (metadata != null) {
-      body.add("metadata", JsonUtils.toJsonElement(metadata));
+      body.add("metadata", JsonUtils.toJsonElement(new LinkedHashMap<>(metadata)));
     }
     addExtraBody(body);
     return body;

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
@@ -28,7 +28,7 @@ public class DeploymentUpdateParam extends FlattenHalfDuplexParamBase {
   @Default private List<JsonObject> initialEvents = null;
   @Default private List<DeploymentResourceParam> resources = null;
   @Default private List<String> vaultIds = null;
-  @Default private Map<String, Object> metadata = null;
+  @Default private Map<String, String> metadata = null;
 
   @Override
   public boolean shouldSerializeExplicitNulls() {

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
@@ -1,0 +1,92 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.alibaba.dashscope.base.FlattenHalfDuplexParamBase;
+import com.alibaba.dashscope.utils.JsonUtils;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class DeploymentUpdateParam extends FlattenHalfDuplexParamBase {
+  @Default private String name = null;
+  @Default private String description = null;
+  @Default private DeploymentAgentParam agent = null;
+  @Default private String environmentId = null;
+  @Default private Boolean clearEnvironment = false;
+  @Default private DeploymentScheduleParam schedule = null;
+  @Default private Boolean clearSchedule = false;
+  @Default private List<JsonObject> initialEvents = null;
+  @Default private List<DeploymentResourceParam> resources = null;
+  @Default private List<String> vaultIds = null;
+  @Default private Map<String, Object> metadata = null;
+
+  @Override
+  public boolean shouldSerializeExplicitNulls() {
+    return Boolean.TRUE.equals(clearEnvironment) || Boolean.TRUE.equals(clearSchedule);
+  }
+
+  @Override
+  public JsonObject getHttpBody() {
+    if (environmentId != null && Boolean.TRUE.equals(clearEnvironment)) {
+      throw new IllegalArgumentException("environmentId and clearEnvironment cannot both be set");
+    }
+    if (schedule != null && Boolean.TRUE.equals(clearSchedule)) {
+      throw new IllegalArgumentException("schedule and clearSchedule cannot both be set");
+    }
+    JsonObject body = new JsonObject();
+    if (name != null) {
+      body.addProperty("name", name);
+    }
+    if (description != null) {
+      body.addProperty("description", description);
+    }
+    if (agent != null) {
+      body.add("agent", JsonUtils.toJsonElement(agent));
+    }
+    if (environmentId != null) {
+      body.addProperty("environment_id", environmentId);
+    } else if (Boolean.TRUE.equals(clearEnvironment)) {
+      body.add("environment_id", JsonNull.INSTANCE);
+    }
+    if (schedule != null) {
+      body.add("schedule", JsonUtils.toJsonElement(schedule));
+    } else if (Boolean.TRUE.equals(clearSchedule)) {
+      body.add("schedule", JsonNull.INSTANCE);
+    }
+    if (initialEvents != null) {
+      JsonArray events = new JsonArray();
+      for (JsonObject event : initialEvents) {
+        events.add(event);
+      }
+      body.add("initial_events", events);
+    }
+    if (resources != null) {
+      JsonArray resourceItems = new JsonArray();
+      for (DeploymentResourceParam resource : resources) {
+        resourceItems.add(JsonUtils.toJsonElement(resource));
+      }
+      body.add("resources", resourceItems);
+    }
+    if (vaultIds != null) {
+      JsonArray vaultItems = new JsonArray();
+      for (String vaultId : vaultIds) {
+        vaultItems.add(vaultId);
+      }
+      body.add("vault_ids", vaultItems);
+    }
+    if (metadata != null) {
+      body.add("metadata", JsonUtils.toJsonElement(metadata));
+    }
+    addExtraBody(body);
+    return body;
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/resource/DeploymentRuns.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/resource/DeploymentRuns.java
@@ -1,0 +1,78 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.resource;
+
+import com.alibaba.dashscope.agentstudio.AgentStudioConstants;
+import com.alibaba.dashscope.agentstudio.model.DeploymentRun;
+import com.alibaba.dashscope.agentstudio.pagination.CursorPage;
+import com.alibaba.dashscope.agentstudio.param.DeploymentRunListParam;
+import com.alibaba.dashscope.api.GeneralApi;
+import com.alibaba.dashscope.base.HalfDuplexParamBase;
+import com.alibaba.dashscope.common.FlattenResultBase;
+import com.alibaba.dashscope.common.GeneralGetParam;
+import com.alibaba.dashscope.exception.InputRequiredException;
+import com.alibaba.dashscope.protocol.ConnectionOptions;
+import com.alibaba.dashscope.protocol.GeneralServiceOption;
+import com.alibaba.dashscope.protocol.HttpMethod;
+import com.alibaba.dashscope.utils.StringUtils;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+
+public final class DeploymentRuns {
+  private final GeneralApi<HalfDuplexParamBase> api;
+  private final String baseUrl;
+  private final String apiKey;
+
+  public DeploymentRuns(String baseUrl, ConnectionOptions connectionOptions, String apiKey) {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.api = connectionOptions != null ? new GeneralApi<>(connectionOptions) : new GeneralApi<>();
+  }
+
+  public DeploymentRun retrieve(String deploymentRunId) {
+    return AsyncHelper.joinAndUnwrap(retrieveAsync(deploymentRunId));
+  }
+
+  public CursorPage<DeploymentRun> list(DeploymentRunListParam param) {
+    return AsyncHelper.joinAndUnwrap(listAsync(param));
+  }
+
+  public CompletableFuture<DeploymentRun> retrieveAsync(String deploymentRunId) {
+    if (deploymentRunId == null || deploymentRunId.isEmpty()) {
+      return AsyncHelper.failedFuture(new InputRequiredException("deploymentRunId is required!"));
+    }
+    GeneralServiceOption opt =
+        AgentStudioConstants.newServiceOption(
+            HttpMethod.GET, StringUtils.format("deployment_runs/%s", deploymentRunId), baseUrl);
+    return AsyncHelper.callAsync(api, getParam(), opt)
+        .thenApply(r -> FlattenResultBase.fromDashScopeResult(r, DeploymentRun.class));
+  }
+
+  public CompletableFuture<CursorPage<DeploymentRun>> listAsync(DeploymentRunListParam param) {
+    if (param == null) {
+      return AsyncHelper.failedFuture(new InputRequiredException("param is required!"));
+    }
+    String query = param.toQueryString();
+    String path = query.isEmpty() ? "deployment_runs" : "deployment_runs?" + query;
+    GeneralServiceOption opt = AgentStudioConstants.newServiceOption(HttpMethod.GET, path, baseUrl);
+    return AsyncHelper.callAsync(api, getParam(), opt)
+        .thenApply(
+            r -> {
+              Type type = new TypeToken<CursorPage<DeploymentRun>>() {}.getType();
+              CursorPage<DeploymentRun> page = FlattenResultBase.fromDashScopeResult(r, type);
+              page.setFetchNext(
+                  cursor ->
+                      listAsync(
+                          DeploymentRunListParam.builder()
+                              .limit(param.getLimit())
+                              .page(cursor)
+                              .build()));
+              return page;
+            });
+  }
+
+  private GeneralGetParam getParam() {
+    return GeneralGetParam.builder().apiKey(apiKey).headers(new HashMap<>()).build();
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/resource/Deployments.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/resource/Deployments.java
@@ -1,0 +1,212 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.resource;
+
+import com.alibaba.dashscope.agentstudio.AgentStudioConstants;
+import com.alibaba.dashscope.agentstudio.model.Deployment;
+import com.alibaba.dashscope.agentstudio.model.DeploymentRun;
+import com.alibaba.dashscope.agentstudio.pagination.CursorPage;
+import com.alibaba.dashscope.agentstudio.param.DeploymentCreateParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentListParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentRunListParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentUpdateParam;
+import com.alibaba.dashscope.api.GeneralApi;
+import com.alibaba.dashscope.base.HalfDuplexParamBase;
+import com.alibaba.dashscope.common.FlattenResultBase;
+import com.alibaba.dashscope.common.GeneralGetParam;
+import com.alibaba.dashscope.exception.InputRequiredException;
+import com.alibaba.dashscope.protocol.ConnectionOptions;
+import com.alibaba.dashscope.protocol.GeneralServiceOption;
+import com.alibaba.dashscope.protocol.HttpMethod;
+import com.alibaba.dashscope.utils.StringUtils;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+
+public final class Deployments {
+  private final GeneralApi<HalfDuplexParamBase> api;
+  private final String baseUrl;
+  private final String apiKey;
+
+  public Deployments(String baseUrl, ConnectionOptions connectionOptions, String apiKey) {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.api = connectionOptions != null ? new GeneralApi<>(connectionOptions) : new GeneralApi<>();
+  }
+
+  public Deployment create(DeploymentCreateParam param) {
+    return AsyncHelper.joinAndUnwrap(createAsync(param));
+  }
+
+  public Deployment retrieve(String deploymentId) {
+    return AsyncHelper.joinAndUnwrap(retrieveAsync(deploymentId));
+  }
+
+  public Deployment update(String deploymentId, DeploymentUpdateParam param) {
+    return AsyncHelper.joinAndUnwrap(updateAsync(deploymentId, param));
+  }
+
+  public CursorPage<Deployment> list(DeploymentListParam param) {
+    return AsyncHelper.joinAndUnwrap(listAsync(param));
+  }
+
+  public Deployment pause(String deploymentId) {
+    return AsyncHelper.joinAndUnwrap(pauseAsync(deploymentId));
+  }
+
+  public Deployment unpause(String deploymentId) {
+    return AsyncHelper.joinAndUnwrap(unpauseAsync(deploymentId));
+  }
+
+  public Deployment archive(String deploymentId) {
+    return AsyncHelper.joinAndUnwrap(archiveAsync(deploymentId));
+  }
+
+  public DeploymentRun run(String deploymentId) {
+    return AsyncHelper.joinAndUnwrap(runAsync(deploymentId));
+  }
+
+  public CursorPage<DeploymentRun> listRuns(String deploymentId, DeploymentRunListParam param) {
+    return AsyncHelper.joinAndUnwrap(listRunsAsync(deploymentId, param));
+  }
+
+  public CompletableFuture<Deployment> createAsync(DeploymentCreateParam param) {
+    if (param == null) {
+      return AsyncHelper.failedFuture(new InputRequiredException("param is required!"));
+    }
+    GeneralServiceOption opt =
+        AgentStudioConstants.newServiceOption(HttpMethod.POST, "deployments", baseUrl);
+    return AsyncHelper.callAsync(api, AgentStudioConstants.withApiKey(apiKey, param), opt)
+        .thenApply(r -> FlattenResultBase.fromDashScopeResult(r, Deployment.class));
+  }
+
+  public CompletableFuture<Deployment> retrieveAsync(String deploymentId) {
+    if (isBlank(deploymentId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("deploymentId is required!"));
+    }
+    GeneralServiceOption opt =
+        AgentStudioConstants.newServiceOption(
+            HttpMethod.GET, StringUtils.format("deployments/%s", deploymentId), baseUrl);
+    return AsyncHelper.callAsync(api, getParam(), opt)
+        .thenApply(r -> FlattenResultBase.fromDashScopeResult(r, Deployment.class));
+  }
+
+  public CompletableFuture<Deployment> updateAsync(
+      String deploymentId, DeploymentUpdateParam param) {
+    if (isBlank(deploymentId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("deploymentId is required!"));
+    }
+    if (param == null) {
+      return AsyncHelper.failedFuture(new InputRequiredException("param is required!"));
+    }
+    GeneralServiceOption opt =
+        AgentStudioConstants.newServiceOption(
+            HttpMethod.POST, StringUtils.format("deployments/%s", deploymentId), baseUrl);
+    return AsyncHelper.callAsync(api, AgentStudioConstants.withApiKey(apiKey, param), opt)
+        .thenApply(r -> FlattenResultBase.fromDashScopeResult(r, Deployment.class));
+  }
+
+  public CompletableFuture<CursorPage<Deployment>> listAsync(DeploymentListParam param) {
+    if (param == null) {
+      return AsyncHelper.failedFuture(new InputRequiredException("param is required!"));
+    }
+    String query = param.toQueryString();
+    String path = query.isEmpty() ? "deployments" : "deployments?" + query;
+    GeneralServiceOption opt = AgentStudioConstants.newServiceOption(HttpMethod.GET, path, baseUrl);
+    return AsyncHelper.callAsync(api, getParam(), opt)
+        .thenApply(
+            r -> {
+              Type type = new TypeToken<CursorPage<Deployment>>() {}.getType();
+              CursorPage<Deployment> page = FlattenResultBase.fromDashScopeResult(r, type);
+              page.setFetchNext(
+                  cursor ->
+                      listAsync(
+                          DeploymentListParam.builder()
+                              .agentId(param.getAgentId())
+                              .keyword(param.getKeyword())
+                              .status(param.getStatus())
+                              .includeArchived(param.getIncludeArchived())
+                              .limit(param.getLimit())
+                              .createdAtGte(param.getCreatedAtGte())
+                              .createdAtLte(param.getCreatedAtLte())
+                              .page(cursor)
+                              .build()));
+              return page;
+            });
+  }
+
+  public CompletableFuture<Deployment> pauseAsync(String deploymentId) {
+    return lifecycleAsync(deploymentId, "pause");
+  }
+
+  public CompletableFuture<Deployment> unpauseAsync(String deploymentId) {
+    return lifecycleAsync(deploymentId, "unpause");
+  }
+
+  public CompletableFuture<Deployment> archiveAsync(String deploymentId) {
+    return lifecycleAsync(deploymentId, "archive");
+  }
+
+  public CompletableFuture<DeploymentRun> runAsync(String deploymentId) {
+    if (isBlank(deploymentId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("deploymentId is required!"));
+    }
+    GeneralServiceOption opt =
+        AgentStudioConstants.newServiceOption(
+            HttpMethod.POST, StringUtils.format("deployments/%s/run", deploymentId), baseUrl);
+    DeploymentUpdateParam param = DeploymentUpdateParam.builder().build();
+    return AsyncHelper.callAsync(api, AgentStudioConstants.withApiKey(apiKey, param), opt)
+        .thenApply(r -> FlattenResultBase.fromDashScopeResult(r, DeploymentRun.class));
+  }
+
+  public CompletableFuture<CursorPage<DeploymentRun>> listRunsAsync(
+      String deploymentId, DeploymentRunListParam param) {
+    if (isBlank(deploymentId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("deploymentId is required!"));
+    }
+    if (param == null) {
+      return AsyncHelper.failedFuture(new InputRequiredException("param is required!"));
+    }
+    String query = param.toQueryString();
+    String basePath = StringUtils.format("deployments/%s/runs", deploymentId);
+    String path = query.isEmpty() ? basePath : basePath + "?" + query;
+    GeneralServiceOption opt = AgentStudioConstants.newServiceOption(HttpMethod.GET, path, baseUrl);
+    return AsyncHelper.callAsync(api, getParam(), opt)
+        .thenApply(
+            r -> {
+              Type type = new TypeToken<CursorPage<DeploymentRun>>() {}.getType();
+              CursorPage<DeploymentRun> page = FlattenResultBase.fromDashScopeResult(r, type);
+              page.setFetchNext(
+                  cursor ->
+                      listRunsAsync(
+                          deploymentId,
+                          DeploymentRunListParam.builder()
+                              .limit(param.getLimit())
+                              .page(cursor)
+                              .build()));
+              return page;
+            });
+  }
+
+  private CompletableFuture<Deployment> lifecycleAsync(String deploymentId, String action) {
+    if (isBlank(deploymentId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("deploymentId is required!"));
+    }
+    GeneralServiceOption opt =
+        AgentStudioConstants.newServiceOption(
+            HttpMethod.POST,
+            StringUtils.format("deployments/%s/%s", deploymentId, action),
+            baseUrl);
+    DeploymentUpdateParam param = DeploymentUpdateParam.builder().build();
+    return AsyncHelper.callAsync(api, AgentStudioConstants.withApiKey(apiKey, param), opt)
+        .thenApply(r -> FlattenResultBase.fromDashScopeResult(r, Deployment.class));
+  }
+
+  private GeneralGetParam getParam() {
+    return GeneralGetParam.builder().apiKey(apiKey).headers(new HashMap<>()).build();
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isEmpty();
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/base/HalfDuplexParamBase.java
+++ b/src/main/java/com/alibaba/dashscope/base/HalfDuplexParamBase.java
@@ -56,6 +56,15 @@ public abstract class HalfDuplexParamBase {
   public abstract JsonObject getHttpBody();
 
   /**
+   * Whether explicitly added JSON null values should be preserved when serializing the HTTP body.
+   *
+   * @return {@code true} to preserve explicit JSON null values
+   */
+  public boolean shouldSerializeExplicitNulls() {
+    return false;
+  }
+
+  /**
    * Get the request input data.
    *
    * @return The input data object.

--- a/src/main/java/com/alibaba/dashscope/common/FlattenResultBase.java
+++ b/src/main/java/com/alibaba/dashscope/common/FlattenResultBase.java
@@ -18,7 +18,9 @@ import lombok.Data;
 @Data
 public abstract class FlattenResultBase {
   /** The request if. */
-  @SerializedName("request_id")
+  @SerializedName(
+      value = "request_id",
+      alternate = {"requestId"})
   private String requestId;
 
   protected FlattenResultBase() {}

--- a/src/main/java/com/alibaba/dashscope/protocol/HalfDuplexRequest.java
+++ b/src/main/java/com/alibaba/dashscope/protocol/HalfDuplexRequest.java
@@ -136,12 +136,19 @@ public class HalfDuplexRequest {
       return HttpRequest.builder()
           .url(getHttpUrl())
           .headers(requestHeaders)
-          .body(body == null ? null : JsonUtils.toJson(body))
+          .body(serializeHttpBody(body))
           .httpMethod(getHttpMethod())
           .build();
     } else {
       return HttpRequest.builder().httpMethod(getHttpMethod()).build();
     }
+  }
+
+  private String serializeHttpBody(JsonObject body) {
+    if (body == null) {
+      return null;
+    }
+    return param.shouldSerializeExplicitNulls() ? body.toString() : JsonUtils.toJson(body);
   }
 
   public JsonObject getWebSocketPayload() {

--- a/src/main/java/com/alibaba/dashscope/protocol/okhttp/OkHttpHttpClient.java
+++ b/src/main/java/com/alibaba/dashscope/protocol/okhttp/OkHttpHttpClient.java
@@ -93,12 +93,26 @@ public final class OkHttpHttpClient implements HalfDuplexClient {
       String requestId = "";
       if (jsonResponse.has(ApiKeywords.REQUEST_ID)) {
         requestId = jsonResponse.get(ApiKeywords.REQUEST_ID).getAsString();
+      } else if (jsonResponse.has("requestId")) {
+        requestId = jsonResponse.get("requestId").getAsString();
       }
       if (jsonResponse.has(ApiKeywords.CODE)) {
         code = jsonResponse.get(ApiKeywords.CODE).getAsString();
       }
       if (jsonResponse.has(ApiKeywords.MESSAGE)) {
         message = jsonResponse.get(ApiKeywords.MESSAGE).getAsString();
+      }
+      if ((code == null || code.isEmpty())
+          && (message == null || message.isEmpty())
+          && jsonResponse.has(ApiKeywords.ERROR)
+          && jsonResponse.get(ApiKeywords.ERROR).isJsonObject()) {
+        JsonObject error = jsonResponse.getAsJsonObject(ApiKeywords.ERROR);
+        if (error.has(ApiKeywords.CODE)) {
+          code = error.get(ApiKeywords.CODE).getAsString();
+        }
+        if (error.has(ApiKeywords.MESSAGE)) {
+          message = error.get(ApiKeywords.MESSAGE).getAsString();
+        }
       }
       return Status.builder()
           .statusCode(statusCode)

--- a/src/test/java/com/alibaba/dashscope/TestAgentStudioDeployments.java
+++ b/src/test/java/com/alibaba/dashscope/TestAgentStudioDeployments.java
@@ -1,0 +1,226 @@
+package com.alibaba.dashscope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alibaba.dashscope.agentstudio.AgentStudioClient;
+import com.alibaba.dashscope.agentstudio.message.ClientEvents;
+import com.alibaba.dashscope.agentstudio.model.Deployment;
+import com.alibaba.dashscope.agentstudio.model.DeploymentRun;
+import com.alibaba.dashscope.agentstudio.pagination.CursorPage;
+import com.alibaba.dashscope.agentstudio.param.DeploymentAgentParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentCreateParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentListParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentResourceParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentRunListParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentScheduleParam;
+import com.alibaba.dashscope.agentstudio.param.DeploymentUpdateParam;
+import com.alibaba.dashscope.agentstudio.resource.DeploymentRuns;
+import com.alibaba.dashscope.agentstudio.resource.Deployments;
+import com.alibaba.dashscope.utils.JsonUtils;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class TestAgentStudioDeployments {
+  private static MockWebServer mockServer;
+  private static JsonObject fixtures;
+  private static String baseUrl;
+
+  @BeforeAll
+  public static void before() throws IOException {
+    mockServer = new MockWebServer();
+    mockServer.start();
+    baseUrl = mockServer.url("/api/v1/agentstudio/").toString();
+    byte[] content = Files.readAllBytes(Paths.get("./src/test/resources/agentstudio.json"));
+    fixtures = JsonUtils.parse(new String(content, StandardCharsets.UTF_8));
+  }
+
+  @AfterAll
+  public static void after() throws IOException {
+    mockServer.close();
+  }
+
+  private void enqueue(String fixtureKey) {
+    JsonObject response = fixtures.get(fixtureKey).getAsJsonObject();
+    mockServer.enqueue(TestUtils.createMockResponse(JsonUtils.toJson(response), 200));
+  }
+
+  @Test
+  public void testCreateAndNestedResponseModels() throws Exception {
+    enqueue("deployment_response");
+    Deployment deployment =
+        deployments()
+            .create(
+                DeploymentCreateParam.builder()
+                    .name("daily-summary")
+                    .description("Summarize orders")
+                    .agent(DeploymentAgentParam.builder().id("agent_01").version(12).build())
+                    .environmentId("env_01")
+                    .schedule(schedule())
+                    .initialEvents(
+                        Collections.singletonList(
+                            ClientEvents.userMessage("Summarize yesterday's orders")))
+                    .resources(
+                        Collections.singletonList(
+                            DeploymentResourceParam.builder()
+                                .type(DeploymentResourceParam.TYPE_FILE)
+                                .fileId("file_01")
+                                .mountPath("/mnt/data")
+                                .build()))
+                    .vaultIds(Collections.singletonList("vault_01"))
+                    .metadata(Collections.singletonMap("biz", "summary"))
+                    .build());
+
+    RecordedRequest request = mockServer.takeRequest();
+    JsonObject body = JsonUtils.parse(request.getBody().readUtf8());
+    assertEquals("POST", request.getMethod());
+    assertTrue(request.getPath().endsWith("/deployments"));
+    assertEquals("agent_01", body.getAsJsonObject("agent").get("id").getAsString());
+    assertEquals("Asia/Shanghai", body.getAsJsonObject("schedule").get("timezone").getAsString());
+    assertEquals(
+        "message",
+        body.getAsJsonArray("initial_events").get(0).getAsJsonObject().get("type").getAsString());
+
+    assertEquals("depl_01", deployment.getId());
+    assertEquals(Integer.valueOf(12), deployment.getAgent().getVersion());
+    assertEquals("qwen3-max", deployment.getAgent().getModel().getId());
+    assertEquals("Asia/Shanghai", deployment.getSchedule().getTimezone());
+    assertEquals("file_01", deployment.getResources().get(0).getFileId());
+    assertEquals("RUN_FAILED", deployment.getPausedReason().getError().getCode());
+    assertEquals("req-depl-01", deployment.getRequestId());
+  }
+
+  @Test
+  public void testUpdateCanExplicitlyClearNullableFields() throws Exception {
+    enqueue("deployment_response");
+    DeploymentUpdateParam updateParam =
+        DeploymentUpdateParam.builder()
+            .clearEnvironment(true)
+            .clearSchedule(true)
+            .resources(Collections.emptyList())
+            .build();
+    assertTrue(updateParam.getClearEnvironment());
+    assertTrue(updateParam.getClearSchedule());
+    assertTrue(updateParam.getHttpBody().has("environment_id"));
+    assertTrue(updateParam.getHttpBody().has("schedule"));
+    deployments().update("depl_01", updateParam);
+
+    RecordedRequest request = mockServer.takeRequest();
+    JsonObject body = JsonUtils.parse(request.getBody().readUtf8());
+    assertEquals("POST", request.getMethod());
+    assertTrue(request.getPath().endsWith("/deployments/depl_01"));
+    assertTrue(body.has("environment_id"), body.toString());
+    assertTrue(body.get("environment_id").isJsonNull());
+    assertTrue(body.has("schedule"), body.toString());
+    assertTrue(body.get("schedule").isJsonNull());
+    assertEquals(0, body.getAsJsonArray("resources").size());
+  }
+
+  @Test
+  public void testListFiltersAndPagination() throws Exception {
+    enqueue("deployment_list_response");
+    CursorPage<Deployment> page =
+        deployments()
+            .list(
+                DeploymentListParam.builder()
+                    .agentId("agent_01")
+                    .keyword("daily")
+                    .status("active")
+                    .includeArchived(true)
+                    .limit(10)
+                    .createdAtGte("2026-07-01T00:00:00Z")
+                    .createdAtLte("2026-07-31T23:59:59Z")
+                    .build());
+
+    RecordedRequest request = mockServer.takeRequest();
+    assertEquals("agent_01", request.getRequestUrl().queryParameter("agent_id"));
+    assertEquals("true", request.getRequestUrl().queryParameter("include_archived"));
+    assertEquals("2026-07-01T00:00:00Z", request.getRequestUrl().queryParameter("created_at[gte]"));
+    assertEquals(1, page.getData().size());
+    assertEquals("next-deployment", page.getNextPage());
+  }
+
+  @Test
+  public void testLifecycleAndDeploymentRunRoutes() throws Exception {
+    enqueue("deployment_response");
+    deployments().pause("depl_01");
+    assertTrue(mockServer.takeRequest().getPath().endsWith("/deployments/depl_01/pause"));
+
+    enqueue("deployment_response");
+    deployments().unpause("depl_01");
+    assertTrue(mockServer.takeRequest().getPath().endsWith("/deployments/depl_01/unpause"));
+
+    enqueue("deployment_response");
+    deployments().archive("depl_01");
+    assertTrue(mockServer.takeRequest().getPath().endsWith("/deployments/depl_01/archive"));
+
+    enqueue("deployment_run_response");
+    DeploymentRun run = deployments().run("depl_01");
+    assertTrue(mockServer.takeRequest().getPath().endsWith("/deployments/depl_01/run"));
+    assertEquals("drun_01", run.getId());
+    assertEquals(Integer.valueOf(12), run.getAgent().getVersion());
+    assertEquals("RUN_FAILED", run.getError().getCode());
+    assertEquals("req-run-01", run.getRequestId());
+
+    enqueue("deployment_run_list_response");
+    CursorPage<DeploymentRun> history =
+        deployments().listRuns("depl_01", DeploymentRunListParam.builder().limit(20).build());
+    assertTrue(mockServer.takeRequest().getPath().contains("/deployments/depl_01/runs"));
+    assertEquals("drun_01", history.getData().get(0).getId());
+
+    enqueue("deployment_run_list_response");
+    CursorPage<DeploymentRun> allRuns =
+        deploymentRuns().list(DeploymentRunListParam.builder().limit(20).build());
+    assertTrue(mockServer.takeRequest().getPath().contains("/deployment_runs?"));
+    assertEquals("depl_01", allRuns.getData().get(0).getDeploymentId());
+    assertEquals("req-run-list", allRuns.getRequestId());
+
+    enqueue("deployment_run_response");
+    DeploymentRun retrieved = deploymentRuns().retrieve("drun_01");
+    assertTrue(mockServer.takeRequest().getPath().endsWith("/deployment_runs/drun_01"));
+    assertEquals("session_01", retrieved.getSessionId());
+  }
+
+  @Test
+  public void testAsyncAndClientAccessors() throws Exception {
+    try (AgentStudioClient client =
+        new AgentStudioClient("test-key", baseUrl, "ws_01", null, null)) {
+      assertNotNull(client.deployments());
+      assertNotNull(client.deploymentRuns());
+    }
+
+    enqueue("deployment_response");
+    Deployment deployment = deployments().retrieveAsync("depl_01").get();
+    mockServer.takeRequest();
+    assertEquals("depl_01", deployment.getId());
+  }
+
+  private static Deployments deployments() {
+    return new Deployments(baseUrl, null, "test-key");
+  }
+
+  private static DeploymentRuns deploymentRuns() {
+    return new DeploymentRuns(baseUrl, null, "test-key");
+  }
+
+  private static DeploymentScheduleParam schedule() {
+    return DeploymentScheduleParam.builder()
+        .type(DeploymentScheduleParam.TYPE_CRON)
+        .expression("0 9 * * 1-5")
+        .timezone("Asia/Shanghai")
+        .build();
+  }
+}

--- a/src/test/java/com/alibaba/dashscope/TestAgentStudioDeployments.java
+++ b/src/test/java/com/alibaba/dashscope/TestAgentStudioDeployments.java
@@ -93,6 +93,7 @@ public class TestAgentStudioDeployments {
     assertEquals(
         "message",
         body.getAsJsonArray("initial_events").get(0).getAsJsonObject().get("type").getAsString());
+    assertEquals("summary", body.getAsJsonObject("metadata").get("biz").getAsString());
 
     assertEquals("depl_01", deployment.getId());
     assertEquals(Integer.valueOf(12), deployment.getAgent().getVersion());
@@ -100,6 +101,7 @@ public class TestAgentStudioDeployments {
     assertEquals("Asia/Shanghai", deployment.getSchedule().getTimezone());
     assertEquals("file_01", deployment.getResources().get(0).getFileId());
     assertEquals("RUN_FAILED", deployment.getPausedReason().getError().getCode());
+    assertEquals("summary", deployment.getMetadata().get("biz"));
     assertEquals("req-depl-01", deployment.getRequestId());
   }
 

--- a/src/test/java/com/alibaba/dashscope/TestAgentStudioDeployments.java
+++ b/src/test/java/com/alibaba/dashscope/TestAgentStudioDeployments.java
@@ -111,6 +111,7 @@ public class TestAgentStudioDeployments {
             .clearEnvironment(true)
             .clearSchedule(true)
             .resources(Collections.emptyList())
+            .metadata(Collections.emptyMap())
             .build();
     assertTrue(updateParam.getClearEnvironment());
     assertTrue(updateParam.getClearSchedule());
@@ -127,6 +128,7 @@ public class TestAgentStudioDeployments {
     assertTrue(body.has("schedule"), body.toString());
     assertTrue(body.get("schedule").isJsonNull());
     assertEquals(0, body.getAsJsonArray("resources").size());
+    assertEquals(0, body.getAsJsonObject("metadata").size());
   }
 
   @Test

--- a/src/test/java/com/alibaba/dashscope/TestHalfDuplexHttpApi.java
+++ b/src/test/java/com/alibaba/dashscope/TestHalfDuplexHttpApi.java
@@ -220,6 +220,34 @@ public class TestHalfDuplexHttpApi {
   }
 
   @Test
+  public void testHttpSendNestedResponseError()
+      throws ApiException, NoApiKeyException, IOException {
+    MockWebServer server = new MockWebServer();
+    String errorCode = "NotFound";
+    String errorMessage = "Agent not found!";
+    JsonObject error = new JsonObject();
+    error.addProperty(ApiKeywords.CODE, errorCode);
+    error.addProperty(ApiKeywords.MESSAGE, errorMessage);
+    JsonObject rsp = new JsonObject();
+    rsp.addProperty("requestId", "req-nested-error");
+    rsp.add(ApiKeywords.ERROR, error);
+    server.enqueue(
+        new MockResponse()
+            .setBody(JsonUtils.toJson(rsp))
+            .setResponseCode(404)
+            .setHeader("content-type", MEDIA_TYPE_APPLICATION_JSON));
+    Constants.baseHttpApiUrl = String.format("http://127.0.0.1:%s", server.getPort());
+    HalfDuplexTestParam param =
+        HalfDuplexTestParam.builder().model("qwen-turbo").parameter("k1", "v1").build();
+
+    ApiException exception = assertThrows(ApiException.class, () -> syncApi.call(param));
+    assertEquals(errorCode, exception.getStatus().getCode());
+    assertEquals(errorMessage, exception.getStatus().getMessage());
+    assertEquals("req-nested-error", exception.getStatus().getRequestId());
+    server.close();
+  }
+
+  @Test
   @SetEnvironmentVariable(key = "DASHSCOPE_NETWORK_LOGGING_LEVEL", value = "BODY")
   public void testHttpSSE() throws ApiException, NoApiKeyException, IOException {
     MockWebServer server = new MockWebServer();

--- a/src/test/resources/agentstudio.json
+++ b/src/test/resources/agentstudio.json
@@ -306,5 +306,100 @@
     ],
     "next_page": null,
     "request_id": "req-009"
+  },
+  "deployment_response": {
+    "id": "depl_01",
+    "type": "deployment",
+    "name": "daily-summary",
+    "description": "Summarize orders",
+    "agent": {
+      "id": "agent_01",
+      "type": "agent",
+      "version": 12,
+      "name": "data-analyst",
+      "model": {"id": "qwen3-max"},
+      "system": "Analyze data."
+    },
+    "environment_id": "env_01",
+    "schedule": {
+      "type": "cron",
+      "expression": "0 9 * * 1-5",
+      "timezone": "Asia/Shanghai",
+      "last_run_at": null,
+      "next_run_at": "2026-07-28T01:00:00Z"
+    },
+    "initial_events": [
+      {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "text", "text": "Summarize yesterday's orders"}]
+      }
+    ],
+    "resources": [
+      {"type": "file", "file_id": "file_01", "mount_path": "/mnt/data"}
+    ],
+    "vault_ids": ["vault_01"],
+    "metadata": {"biz": "summary"},
+    "status": "paused",
+    "paused_reason": {
+      "type": "error",
+      "error": {"code": "RUN_FAILED", "message": "failed"}
+    },
+    "archived_at": null,
+    "created_at": "2026-07-27T01:00:00Z",
+    "updated_at": "2026-07-27T01:00:00Z",
+    "requestId": "req-depl-01"
+  },
+  "deployment_list_response": {
+    "data": [
+      {
+        "id": "depl_01",
+        "type": "deployment",
+        "name": "daily-summary",
+        "agent": {
+          "id": "agent_01",
+          "type": "agent",
+          "version": 12,
+          "name": "data-analyst",
+          "model": {"id": "qwen3-max"}
+        },
+        "status": "active",
+        "created_at": "2026-07-27T01:00:00Z",
+        "updated_at": "2026-07-27T01:00:00Z"
+      }
+    ],
+    "next_page": "next-deployment",
+    "requestId": "req-depl-list"
+  },
+  "deployment_run_response": {
+    "id": "drun_01",
+    "type": "deployment_run",
+    "deployment_id": "depl_01",
+    "agent": {"id": "agent_01", "version": 12},
+    "session_id": "session_01",
+    "trigger_source": "manual",
+    "status": "failed",
+    "error": {"code": "RUN_FAILED", "message": "failed"},
+    "started_at": "2026-07-27T01:00:00.123Z",
+    "finished_at": "2026-07-27T01:01:00.456Z",
+    "requestId": "req-run-01"
+  },
+  "deployment_run_list_response": {
+    "data": [
+      {
+        "id": "drun_01",
+        "type": "deployment_run",
+        "deployment_id": "depl_01",
+        "agent": {"id": "agent_01", "version": 12},
+        "session_id": "session_01",
+        "trigger_source": "manual",
+        "status": "succeeded",
+        "error": null,
+        "started_at": "2026-07-27T01:00:00.123Z",
+        "finished_at": "2026-07-27T01:01:00.456Z"
+      }
+    ],
+    "next_page": "next-run",
+    "requestId": "req-run-list"
   }
 }


### PR DESCRIPTION
## Summary

- add managed agent deployment lifecycle and deployment run APIs
- add request/response models, pagination, and MockWebServer coverage
- support explicit metadata clearing and restrict deployment metadata to string values
- preserve nested service errors in ApiException responses

## Testing

- `mvn -q -Dtest=TestAgentStudioDeployments test`
- `mvn -q -DskipTests package`
