### PR TITLE
fix(multimodal): fix UnsupportedOperationException for BigDecimal/BigInteger in message content

### DIFF
--- a/src/main/java/com/alibaba/dashscope/common/MultiModalMessageAdapter.java
+++ b/src/main/java/com/alibaba/dashscope/common/MultiModalMessageAdapter.java
@@ -46,12 +46,10 @@ public class MultiModalMessageAdapter extends TypeAdapter<MultiModalMessage> {
       out.value(((Number) value).doubleValue());
     } else if (value instanceof Short || value instanceof Byte) {
       out.value(((Number) value).intValue());
-    } else if (value instanceof BigDecimal) {
-      // Use jsonValue to write as JSON number, not string
-      out.jsonValue(((BigDecimal) value).toPlainString());
-    } else if (value instanceof BigInteger) {
-      // Use jsonValue to write as JSON number, not string
-      out.jsonValue(((BigInteger) value).toString());
+    } else if (value instanceof BigDecimal || value instanceof BigInteger) {
+      // value(Number) keeps the JSON number unquoted and is JsonTreeWriter-safe,
+      // unlike jsonValue which throws UnsupportedOperationException under toJsonTree
+      out.value((Number) value);
     } else if (value instanceof Boolean) {
       out.value((Boolean) value);
     } else if (value instanceof Character) {
@@ -66,9 +64,9 @@ public class MultiModalMessageAdapter extends TypeAdapter<MultiModalMessage> {
     } else if (value instanceof Map) {
       writeMapObject(out, (Map<String, Object>) value);
     } else {
-      // For unsupported types, serialize using Gson to JSON string
-      String jsonStr = JsonUtils.toJson(value);
-      out.jsonValue(jsonStr);
+      // Serialize arbitrary objects through Gson directly into the writer;
+      // works for both streaming and JsonTreeWriter (toJsonTree) paths
+      JsonUtils.gson.toJson(value, value.getClass(), out);
     }
   }
 

--- a/src/test/java/com/alibaba/dashscope/TestMultiModalMessageAdapter.java
+++ b/src/test/java/com/alibaba/dashscope/TestMultiModalMessageAdapter.java
@@ -1,0 +1,87 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alibaba.dashscope.common.MultiModalMessage;
+import com.alibaba.dashscope.utils.JsonUtils;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class TestMultiModalMessageAdapter {
+
+  private static class CustomContent {
+    public String url = "http://example.com/a.png";
+  }
+
+  @Test
+  public void testBigDecimalAndBigIntegerViaToJsonTree() {
+    Map<String, Object> videoContent = new HashMap<>();
+    videoContent.put("video", Arrays.asList("base64img1", "base64img2"));
+    videoContent.put("fps", new BigDecimal("0.1"));
+    videoContent.put("nframes", new BigInteger("12345678901234567890"));
+
+    MultiModalMessage msg =
+        MultiModalMessage.builder()
+            .role("user")
+            .content(
+                Arrays.asList(
+                    Collections.singletonMap("text", (Object) "describe this video"), videoContent))
+            .build();
+
+    // MultiModalConversationParam.getInput() serializes through Gson.toJsonTree,
+    // whose JsonTreeWriter does not support jsonValue()
+    JsonArray array = JsonUtils.toJsonArray(Arrays.asList(msg));
+    JsonObject video =
+        array.get(0).getAsJsonObject().getAsJsonArray("content").get(1).getAsJsonObject();
+    assertTrue(video.get("fps").isJsonPrimitive());
+    assertTrue(video.get("fps").getAsJsonPrimitive().isNumber());
+    assertEquals(new BigDecimal("0.1"), video.get("fps").getAsBigDecimal());
+    assertEquals(new BigInteger("12345678901234567890"), video.get("nframes").getAsBigInteger());
+  }
+
+  @Test
+  public void testUnsupportedTypeFallbackViaToJsonTree() {
+    Map<String, Object> content = new HashMap<>();
+    content.put("custom", new CustomContent());
+
+    MultiModalMessage msg =
+        MultiModalMessage.builder().role("user").content(Arrays.asList(content)).build();
+
+    JsonArray array = JsonUtils.toJsonArray(Arrays.asList(msg));
+    JsonObject custom =
+        array
+            .get(0)
+            .getAsJsonObject()
+            .getAsJsonArray("content")
+            .get(0)
+            .getAsJsonObject()
+            .getAsJsonObject("custom");
+    assertEquals("http://example.com/a.png", custom.get("url").getAsString());
+  }
+
+  @Test
+  public void testStreamingWriterPathStillWorks() {
+    Map<String, Object> content = new HashMap<>();
+    content.put("fps", new BigDecimal("0.1"));
+    content.put("custom", new CustomContent());
+
+    MultiModalMessage msg =
+        MultiModalMessage.builder().role("user").content(Arrays.asList(content)).build();
+
+    String json = JsonUtils.toJson(msg);
+    JsonObject parsed = JsonUtils.parse(json);
+    JsonObject first = parsed.getAsJsonArray("content").get(0).getAsJsonObject();
+    assertEquals(new BigDecimal("0.1"), first.get("fps").getAsBigDecimal());
+    assertEquals(
+        "http://example.com/a.png", first.getAsJsonObject("custom").get("url").getAsString());
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #250: `MultiModalMessageAdapter.writeValue()` used `JsonWriter.jsonValue()` for `BigDecimal`/`BigInteger` values and the unsupported-type fallback, but `MultiModalConversationParam.getInput()` serializes messages via `Gson.toJsonTree()`, whose `JsonTreeWriter.jsonValue()` throws `UnsupportedOperationException` — crashing requests (e.g. a `BigDecimal` `fps` in video content) before sending
- Regression introduced by #244, first shipped in v2.22.25
- Write numbers with `value(Number)` (unquoted, JsonTreeWriter-safe) and serialize fallback objects directly into the writer via `gson.toJson(value, type, out)`

## Test plan
- [x] Added `TestMultiModalMessageAdapter` (3 cases): BigDecimal/BigInteger and fallback object through the `toJsonTree` path, plus the streaming-writer path
- [x] All 3 tests pass on the fix; 2 fail on the pre-fix code (reproduces the issue)