### PR TITLE
revert(protocol/websocket): keep fixed status code 44 for handshake failure

### DIFF
--- a/src/main/java/com/alibaba/dashscope/protocol/okhttp/OkHttpWebSocketClient.java
+++ b/src/main/java/com/alibaba/dashscope/protocol/okhttp/OkHttpWebSocketClient.java
@@ -206,7 +206,7 @@ public class OkHttpWebSocketClient extends WebSocketListener
         httpStatusCode = extractHttpStatusCode(ex);
         // The server answered the handshake with a client error (401, 403, 429, ...): retrying
         // cannot change the outcome and would only add pressure on a server already refusing us,
-        // so surface the status code to the caller right away.
+        // so give up immediately.
         if (isClientError(httpStatusCode, errorMessage)) {
           log.warn(
               "Websocket handshake refused with http status {}, will not retry: {}",
@@ -228,14 +228,13 @@ public class OkHttpWebSocketClient extends WebSocketListener
         }
       }
     }
+    // The handshake status code only drives the retry decision above: callers rely on the fixed
+    // websocket failure status code, so it must not leak into the reported status.
     throw new ApiException(
         Status.builder()
             .code("ConnectionError")
             .message(errorMessage)
-            .statusCode(
-                httpStatusCode > 0
-                    ? httpStatusCode
-                    : Constants.DASHSCOPE_WEBSOCKET_FAILED_STATUS_CODE)
+            .statusCode(Constants.DASHSCOPE_WEBSOCKET_FAILED_STATUS_CODE)
             .build());
   }
 

--- a/src/test/java/com/alibaba/dashscope/TestFullDuplexErrorHandling.java
+++ b/src/test/java/com/alibaba/dashscope/TestFullDuplexErrorHandling.java
@@ -330,8 +330,10 @@ public class TestFullDuplexErrorHandling {
               api.duplexCall(param).blockingForEach(msg -> {});
             });
     long elapsed = System.currentTimeMillis() - start;
-    // The status code answered by the server is reported to the caller as is.
-    assertEquals(429, thrown.getStatus().getStatusCode());
+    // The handshake http status only drives the retry decision: callers keep seeing the fixed
+    // websocket failure status code.
+    assertEquals(
+        Constants.DASHSCOPE_WEBSOCKET_FAILED_STATUS_CODE, thrown.getStatus().getStatusCode());
     // A client error is final: a single handshake must have been attempted.
     assertEquals(1, server.getRequestCount());
     // And no backoff must have been waited for.
@@ -359,7 +361,8 @@ public class TestFullDuplexErrorHandling {
               api.duplexCall(param).blockingForEach(msg -> {});
             });
     long elapsed = System.currentTimeMillis() - start;
-    assertEquals(500, thrown.getStatus().getStatusCode());
+    assertEquals(
+        Constants.DASHSCOPE_WEBSOCKET_FAILED_STATUS_CODE, thrown.getStatus().getStatusCode());
     // A transient failure is retried up to the attempt limit.
     assertEquals(3, server.getRequestCount());
     // Two backoffs only: the last attempt must not be followed by a wait.


### PR DESCRIPTION
The 4xx fail-fast change started surfacing the upstream HTTP status code (e.g. 401) in the ApiException status, which breaks callers that rely on the fixed websocket failure status code 44.

Restore Constants.DASHSCOPE_WEBSOCKET_FAILED_STATUS_CODE as the reported status code. The handshake HTTP status code is still extracted, but it is now only used to decide whether a retry is pointless.