### PR TITLE
feat(agentstudio): add webhook endpoint APIs

### DIFF
--- a/src/main/java/com/alibaba/dashscope/agentstudio/AgentStudioClient.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/AgentStudioClient.java
@@ -7,6 +7,7 @@ import com.alibaba.dashscope.agentstudio.resource.Files;
 import com.alibaba.dashscope.agentstudio.resource.Sessions;
 import com.alibaba.dashscope.agentstudio.resource.Skills;
 import com.alibaba.dashscope.agentstudio.resource.Vaults;
+import com.alibaba.dashscope.agentstudio.resource.WebhookEndpoints;
 import com.alibaba.dashscope.protocol.ConnectionOptions;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
@@ -19,6 +20,7 @@ public class AgentStudioClient implements Closeable {
   private final Skills skills;
   private final Vaults vaults;
   private final Files files;
+  private final WebhookEndpoints webhookEndpoints;
   private final String baseUrl;
 
   public AgentStudioClient() {
@@ -46,6 +48,7 @@ public class AgentStudioClient implements Closeable {
     this.files = new Files(this.baseUrl, connectionOptions, apiKey);
     this.skills = new Skills(this.baseUrl, connectionOptions, apiKey, this.files);
     this.vaults = new Vaults(this.baseUrl, connectionOptions, apiKey);
+    this.webhookEndpoints = new WebhookEndpoints(this.baseUrl, connectionOptions, apiKey);
   }
 
   public static Builder builder() {
@@ -111,6 +114,10 @@ public class AgentStudioClient implements Closeable {
 
   public Files files() {
     return files;
+  }
+
+  public WebhookEndpoints webhookEndpoints() {
+    return webhookEndpoints;
   }
 
   public String getBaseUrl() {

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDelivery.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDelivery.java
@@ -4,7 +4,7 @@ package com.alibaba.dashscope.agentstudio.model;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
-/** Delivery audit information attached to an endpoint event. */
+/** Delivery information attached to an endpoint event. */
 @Data
 public class WebhookDelivery {
   @SerializedName("webhook_id")

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDelivery.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDelivery.java
@@ -1,0 +1,27 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+/** Delivery audit information attached to an endpoint event. */
+@Data
+public class WebhookDelivery {
+  @SerializedName("webhook_id")
+  private String webhookId;
+
+  @SerializedName("status")
+  private WebhookDeliveryStatus status;
+
+  @SerializedName("attempt_count")
+  private Integer attemptCount;
+
+  @SerializedName("delivery_at")
+  private String deliveryAt;
+
+  @SerializedName("finish_at")
+  private String finishAt;
+
+  @SerializedName("failure_reason")
+  private String failureReason;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDeliveryStatus.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDeliveryStatus.java
@@ -1,7 +1,7 @@
 // Copyright (c) Alibaba, Inc. and its affiliates.
 package com.alibaba.dashscope.agentstudio.model;
 
-/** Webhook delivery audit status. */
+/** Webhook delivery status. */
 public enum WebhookDeliveryStatus {
   /** The delivery is waiting to start. */
   PENDING,

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDeliveryStatus.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDeliveryStatus.java
@@ -1,0 +1,23 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+/** Webhook delivery audit status. */
+public enum WebhookDeliveryStatus {
+  /** The delivery is waiting to start. */
+  PENDING,
+
+  /** The delivery is currently being sent. */
+  DELIVERING,
+
+  /** The delivery is waiting for its next retry. */
+  WAITING_RETRY,
+
+  /** The delivery completed successfully. */
+  SUCCEEDED,
+
+  /** The delivery exhausted all attempts. */
+  FAILED,
+
+  /** The delivery was canceled because its endpoint was disabled or deleted. */
+  CANCELED
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDisabledReason.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookDisabledReason.java
@@ -1,0 +1,20 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+/** Reason why a webhook endpoint was disabled. */
+public enum WebhookDisabledReason {
+  /** The endpoint was disabled manually. */
+  MANUAL,
+
+  /** The endpoint reached the consecutive delivery failure threshold. */
+  CONSECUTIVE_DELIVERY_FAILURES,
+
+  /** The endpoint returned an HTTP redirect response. */
+  REDIRECT_RESPONSE,
+
+  /** The endpoint failed server-side request forgery validation. */
+  SSRF_VALIDATION_FAILED,
+
+  /** The endpoint failed Transport Layer Security validation. */
+  TLS_VALIDATION_FAILED
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEndpoint.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEndpoint.java
@@ -1,0 +1,49 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.alibaba.dashscope.common.FlattenResultBase;
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/** Managed Agent webhook endpoint. */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class WebhookEndpoint extends FlattenResultBase {
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("description")
+  private String description;
+
+  @SerializedName("url")
+  private String url;
+
+  @SerializedName("events")
+  private List<String> events;
+
+  @SerializedName("status")
+  private WebhookStatus status;
+
+  @SerializedName("disabled_reason")
+  private WebhookDisabledReason disabledReason;
+
+  @SerializedName("consecutive_fail")
+  private Integer consecutiveFail;
+
+  @SerializedName("last_success_at")
+  private String lastSuccessAt;
+
+  @SerializedName("last_failure_at")
+  private String lastFailureAt;
+
+  @SerializedName("signing_secret")
+  private String signingSecret;
+
+  @SerializedName("created_at")
+  private String createdAt;
+
+  @SerializedName("updated_at")
+  private String updatedAt;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEndpointList.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEndpointList.java
@@ -1,0 +1,16 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.alibaba.dashscope.common.FlattenResultBase;
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/** Non-paginated list of webhook endpoints in the current workspace. */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class WebhookEndpointList extends FlattenResultBase {
+  @SerializedName("data")
+  private List<WebhookEndpoint> data;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEvent.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEvent.java
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-/** Webhook event envelope returned by test and endpoint audit APIs. */
+/** Webhook event envelope returned by test and endpoint event APIs. */
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class WebhookEvent extends FlattenResultBase {

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEvent.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEvent.java
@@ -1,0 +1,27 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.alibaba.dashscope.common.FlattenResultBase;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/** Webhook event envelope returned by test and endpoint audit APIs. */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class WebhookEvent extends FlattenResultBase {
+  @SerializedName("type")
+  private String type;
+
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("created_at")
+  private String createdAt;
+
+  @SerializedName("data")
+  private WebhookEventData data;
+
+  @SerializedName("delivery")
+  private WebhookDelivery delivery;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEventData.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEventData.java
@@ -1,0 +1,28 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.Map;
+import lombok.Data;
+
+/** Resource data carried by a webhook event envelope. */
+@Data
+public class WebhookEventData {
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("type")
+  private String type;
+
+  @SerializedName("workspace_id")
+  private String workspaceId;
+
+  @SerializedName("session_thread_id")
+  private String sessionThreadId;
+
+  @SerializedName("vault_id")
+  private String vaultId;
+
+  @SerializedName("extensions")
+  private Map<String, Object> extensions;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEventType.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEventType.java
@@ -1,0 +1,106 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+/** Event types accepted by webhook endpoint subscriptions. */
+public final class WebhookEventType {
+  /** Subscribe to every supported event type. */
+  public static final String ALL = "*";
+
+  /** A session was created. */
+  public static final String SESSION_CREATED = "session.created";
+
+  /** A session was updated. */
+  public static final String SESSION_UPDATED = "session.updated";
+
+  /** A session was archived. */
+  public static final String SESSION_ARCHIVED = "session.archived";
+
+  /** A session was deleted. */
+  public static final String SESSION_DELETED = "session.deleted";
+
+  /** A session run started. */
+  public static final String SESSION_STATUS_RUN_STARTED = "session.status_run_started";
+
+  /** A session entered the idle state. */
+  public static final String SESSION_STATUS_IDLED = "session.status_idled";
+
+  /** A session entered the terminated state. */
+  public static final String SESSION_STATUS_TERMINATED = "session.status_terminated";
+
+  /** A session thread was created. */
+  public static final String SESSION_THREAD_CREATED = "session.thread_created";
+
+  /** A session thread run started. */
+  public static final String SESSION_THREAD_RUN_STARTED = "session.thread_run_started";
+
+  /** A session thread entered the idle state. */
+  public static final String SESSION_THREAD_IDLED = "session.thread_idled";
+
+  /** A session thread entered the terminated state. */
+  public static final String SESSION_THREAD_TERMINATED = "session.thread_terminated";
+
+  /** An agent was created. */
+  public static final String AGENT_CREATED = "agent.created";
+
+  /** An agent was updated. */
+  public static final String AGENT_UPDATED = "agent.updated";
+
+  /** An agent was archived. */
+  public static final String AGENT_ARCHIVED = "agent.archived";
+
+  /** A deployment was created. */
+  public static final String DEPLOYMENT_CREATED = "deployment.created";
+
+  /** A deployment was updated. */
+  public static final String DEPLOYMENT_UPDATED = "deployment.updated";
+
+  /** A deployment was archived. */
+  public static final String DEPLOYMENT_ARCHIVED = "deployment.archived";
+
+  /** A deployment was paused. */
+  public static final String DEPLOYMENT_PAUSED = "deployment.paused";
+
+  /** A deployment was resumed. */
+  public static final String DEPLOYMENT_UNPAUSED = "deployment.unpaused";
+
+  /** A deployment run started. */
+  public static final String DEPLOYMENT_RUN_STARTED = "deployment_run.started";
+
+  /** A deployment run failed. */
+  public static final String DEPLOYMENT_RUN_FAILED = "deployment_run.failed";
+
+  /** A deployment run succeeded. */
+  public static final String DEPLOYMENT_RUN_SUCCEEDED = "deployment_run.succeeded";
+
+  /** An environment was created. */
+  public static final String ENVIRONMENT_CREATED = "environment.created";
+
+  /** An environment was updated. */
+  public static final String ENVIRONMENT_UPDATED = "environment.updated";
+
+  /** An environment was archived. */
+  public static final String ENVIRONMENT_ARCHIVED = "environment.archived";
+
+  /** An environment was deleted. */
+  public static final String ENVIRONMENT_DELETED = "environment.deleted";
+
+  /** A vault was created. */
+  public static final String VAULT_CREATED = "vault.created";
+
+  /** A vault was archived. */
+  public static final String VAULT_ARCHIVED = "vault.archived";
+
+  /** A vault was deleted. */
+  public static final String VAULT_DELETED = "vault.deleted";
+
+  /** A vault credential was created. */
+  public static final String VAULT_CREDENTIAL_CREATED = "vault_credential.created";
+
+  /** A vault credential was archived. */
+  public static final String VAULT_CREDENTIAL_ARCHIVED = "vault_credential.archived";
+
+  /** A vault credential was deleted. */
+  public static final String VAULT_CREDENTIAL_DELETED = "vault_credential.deleted";
+
+  private WebhookEventType() {}
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEventType.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookEventType.java
@@ -3,9 +3,6 @@ package com.alibaba.dashscope.agentstudio.model;
 
 /** Event types accepted by webhook endpoint subscriptions. */
 public final class WebhookEventType {
-  /** Subscribe to every supported event type. */
-  public static final String ALL = "*";
-
   /** A session was created. */
   public static final String SESSION_CREATED = "session.created";
 

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookSecretReset.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookSecretReset.java
@@ -1,0 +1,21 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+import com.alibaba.dashscope.common.FlattenResultBase;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/** Result returned after resetting a webhook signing secret. */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class WebhookSecretReset extends FlattenResultBase {
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("signing_secret")
+  private String signingSecret;
+
+  @SerializedName("updated_at")
+  private String updatedAt;
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookStatus.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/WebhookStatus.java
@@ -1,0 +1,11 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.model;
+
+/** Webhook endpoint activation status. */
+public enum WebhookStatus {
+  /** The endpoint can receive webhook deliveries. */
+  ACTIVE,
+
+  /** The endpoint does not receive webhook deliveries. */
+  DISABLED
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/WebhookEndpointCreateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/WebhookEndpointCreateParam.java
@@ -1,0 +1,34 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.alibaba.dashscope.base.FlattenHalfDuplexParamBase;
+import com.alibaba.dashscope.utils.JsonUtils;
+import com.google.gson.JsonObject;
+import java.util.List;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
+
+/** Parameters for creating a webhook endpoint. */
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class WebhookEndpointCreateParam extends FlattenHalfDuplexParamBase {
+  @Default private String description = null;
+  @NonNull private String url;
+  @NonNull private List<String> events;
+
+  @Override
+  public JsonObject getHttpBody() {
+    JsonObject body = new JsonObject();
+    if (description != null) {
+      body.addProperty("description", description);
+    }
+    body.addProperty("url", url);
+    body.add("events", JsonUtils.toJsonElement(events));
+    addExtraBody(body);
+    return body;
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/WebhookEndpointUpdateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/WebhookEndpointUpdateParam.java
@@ -1,0 +1,37 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.alibaba.dashscope.base.FlattenHalfDuplexParamBase;
+import com.alibaba.dashscope.utils.JsonUtils;
+import com.google.gson.JsonObject;
+import java.util.List;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+/** Parameters for updating a webhook endpoint. */
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class WebhookEndpointUpdateParam extends FlattenHalfDuplexParamBase {
+  @Default private String description = null;
+  @Default private String url = null;
+  @Default private List<String> events = null;
+
+  @Override
+  public JsonObject getHttpBody() {
+    JsonObject body = new JsonObject();
+    if (description != null) {
+      body.addProperty("description", description);
+    }
+    if (url != null) {
+      body.addProperty("url", url);
+    }
+    if (events != null) {
+      body.add("events", JsonUtils.toJsonElement(events));
+    }
+    addExtraBody(body);
+    return body;
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/WebhookEventListParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/WebhookEventListParam.java
@@ -1,0 +1,31 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.param;
+
+import com.alibaba.dashscope.agentstudio.AgentStudioConstants;
+import com.alibaba.dashscope.base.FlattenHalfDuplexParamBase;
+import com.google.gson.JsonObject;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+/** Cursor pagination parameters for an endpoint's webhook event audit records. */
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class WebhookEventListParam extends FlattenHalfDuplexParamBase {
+  @Default private Integer limit = null;
+  @Default private String page = null;
+
+  @Override
+  public JsonObject getHttpBody() {
+    return new JsonObject();
+  }
+
+  public String toQueryString() {
+    StringBuilder query = new StringBuilder();
+    AgentStudioConstants.appendParam(query, "limit", limit);
+    AgentStudioConstants.appendParam(query, "page", page);
+    return query.toString();
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/WebhookEventListParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/WebhookEventListParam.java
@@ -9,7 +9,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
-/** Cursor pagination parameters for an endpoint's webhook event audit records. */
+/** Cursor pagination parameters for an endpoint's webhook events. */
 @Data
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/com/alibaba/dashscope/agentstudio/resource/WebhookEndpoints.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/resource/WebhookEndpoints.java
@@ -1,0 +1,235 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+package com.alibaba.dashscope.agentstudio.resource;
+
+import com.alibaba.dashscope.agentstudio.AgentStudioConstants;
+import com.alibaba.dashscope.agentstudio.model.WebhookEndpoint;
+import com.alibaba.dashscope.agentstudio.model.WebhookEndpointList;
+import com.alibaba.dashscope.agentstudio.model.WebhookEvent;
+import com.alibaba.dashscope.agentstudio.model.WebhookSecretReset;
+import com.alibaba.dashscope.agentstudio.pagination.CursorPage;
+import com.alibaba.dashscope.agentstudio.param.WebhookEndpointCreateParam;
+import com.alibaba.dashscope.agentstudio.param.WebhookEndpointUpdateParam;
+import com.alibaba.dashscope.agentstudio.param.WebhookEventListParam;
+import com.alibaba.dashscope.api.GeneralApi;
+import com.alibaba.dashscope.base.HalfDuplexParamBase;
+import com.alibaba.dashscope.common.FlattenResultBase;
+import com.alibaba.dashscope.common.GeneralGetParam;
+import com.alibaba.dashscope.exception.InputRequiredException;
+import com.alibaba.dashscope.protocol.ConnectionOptions;
+import com.alibaba.dashscope.protocol.GeneralServiceOption;
+import com.alibaba.dashscope.protocol.HttpMethod;
+import com.alibaba.dashscope.utils.StringUtils;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+
+/** Managed Agent webhook endpoint APIs. */
+public final class WebhookEndpoints {
+  /** Relative path of the webhook endpoint collection. */
+  private static final String RESOURCE_PATH = "webhook_endpoints";
+
+  private final GeneralApi<HalfDuplexParamBase> api;
+  private final String baseUrl;
+  private final String apiKey;
+
+  public WebhookEndpoints(String baseUrl, ConnectionOptions connectionOptions, String apiKey) {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.api = connectionOptions != null ? new GeneralApi<>(connectionOptions) : new GeneralApi<>();
+  }
+
+  public WebhookEndpoint create(WebhookEndpointCreateParam param) {
+    return AsyncHelper.joinAndUnwrap(createAsync(param));
+  }
+
+  public WebhookEndpoint retrieve(String webhookId) {
+    return AsyncHelper.joinAndUnwrap(retrieveAsync(webhookId));
+  }
+
+  public WebhookEndpoint get(String webhookId) {
+    return retrieve(webhookId);
+  }
+
+  public WebhookEndpointList list() {
+    return AsyncHelper.joinAndUnwrap(listAsync());
+  }
+
+  public WebhookEndpoint update(String webhookId, WebhookEndpointUpdateParam param) {
+    return AsyncHelper.joinAndUnwrap(updateAsync(webhookId, param));
+  }
+
+  public void delete(String webhookId) {
+    AsyncHelper.joinAndUnwrap(deleteAsync(webhookId));
+  }
+
+  public WebhookEndpoint enable(String webhookId) {
+    return AsyncHelper.joinAndUnwrap(enableAsync(webhookId));
+  }
+
+  public WebhookEndpoint disable(String webhookId) {
+    return AsyncHelper.joinAndUnwrap(disableAsync(webhookId));
+  }
+
+  public WebhookEvent test(String webhookId) {
+    return AsyncHelper.joinAndUnwrap(testAsync(webhookId));
+  }
+
+  public WebhookSecretReset resetSecret(String webhookId) {
+    return AsyncHelper.joinAndUnwrap(resetSecretAsync(webhookId));
+  }
+
+  public CursorPage<WebhookEvent> listEvents(String webhookId) {
+    return listEvents(webhookId, WebhookEventListParam.builder().build());
+  }
+
+  public CursorPage<WebhookEvent> listEvents(
+      String webhookId, WebhookEventListParam param) {
+    return AsyncHelper.joinAndUnwrap(listEventsAsync(webhookId, param));
+  }
+
+  public CompletableFuture<WebhookEndpoint> createAsync(WebhookEndpointCreateParam param) {
+    if (param == null) {
+      return AsyncHelper.failedFuture(new InputRequiredException("param is required!"));
+    }
+    GeneralServiceOption option =
+        AgentStudioConstants.newServiceOption(HttpMethod.POST, RESOURCE_PATH, baseUrl);
+    return AsyncHelper.callAsync(api, AgentStudioConstants.withApiKey(apiKey, param), option)
+        .thenApply(result -> FlattenResultBase.fromDashScopeResult(result, WebhookEndpoint.class));
+  }
+
+  public CompletableFuture<WebhookEndpoint> retrieveAsync(String webhookId) {
+    if (isEmpty(webhookId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("webhookId is required!"));
+    }
+    GeneralServiceOption option =
+        AgentStudioConstants.newServiceOption(
+            HttpMethod.GET, StringUtils.format("%s/%s", RESOURCE_PATH, webhookId), baseUrl);
+    return AsyncHelper.callAsync(api, emptyParam(), option)
+        .thenApply(result -> FlattenResultBase.fromDashScopeResult(result, WebhookEndpoint.class));
+  }
+
+  public CompletableFuture<WebhookEndpoint> getAsync(String webhookId) {
+    return retrieveAsync(webhookId);
+  }
+
+  public CompletableFuture<WebhookEndpointList> listAsync() {
+    GeneralServiceOption option =
+        AgentStudioConstants.newServiceOption(HttpMethod.GET, RESOURCE_PATH, baseUrl);
+    return AsyncHelper.callAsync(api, emptyParam(), option)
+        .thenApply(
+            result ->
+                FlattenResultBase.fromDashScopeResult(result, WebhookEndpointList.class));
+  }
+
+  public CompletableFuture<WebhookEndpoint> updateAsync(
+      String webhookId, WebhookEndpointUpdateParam param) {
+    if (isEmpty(webhookId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("webhookId is required!"));
+    }
+    if (param == null) {
+      return AsyncHelper.failedFuture(new InputRequiredException("param is required!"));
+    }
+    GeneralServiceOption option =
+        AgentStudioConstants.newServiceOption(
+            HttpMethod.PUT, StringUtils.format("%s/%s", RESOURCE_PATH, webhookId), baseUrl);
+    return AsyncHelper.callAsync(api, AgentStudioConstants.withApiKey(apiKey, param), option)
+        .thenApply(result -> FlattenResultBase.fromDashScopeResult(result, WebhookEndpoint.class));
+  }
+
+  public CompletableFuture<Void> deleteAsync(String webhookId) {
+    if (isEmpty(webhookId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("webhookId is required!"));
+    }
+    GeneralServiceOption option =
+        AgentStudioConstants.newServiceOption(
+            HttpMethod.DELETE, StringUtils.format("%s/%s", RESOURCE_PATH, webhookId), baseUrl);
+    return AsyncHelper.callAsync(api, emptyParam(), option).thenApply(result -> null);
+  }
+
+  public CompletableFuture<WebhookEndpoint> enableAsync(String webhookId) {
+    return endpointActionAsync(webhookId, "enable");
+  }
+
+  public CompletableFuture<WebhookEndpoint> disableAsync(String webhookId) {
+    return endpointActionAsync(webhookId, "disable");
+  }
+
+  public CompletableFuture<WebhookEvent> testAsync(String webhookId) {
+    if (isEmpty(webhookId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("webhookId is required!"));
+    }
+    GeneralServiceOption option = actionOption(webhookId, "test");
+    return AsyncHelper.callAsync(api, emptyParam(), option)
+        .thenApply(result -> FlattenResultBase.fromDashScopeResult(result, WebhookEvent.class));
+  }
+
+  public CompletableFuture<WebhookSecretReset> resetSecretAsync(String webhookId) {
+    if (isEmpty(webhookId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("webhookId is required!"));
+    }
+    GeneralServiceOption option = actionOption(webhookId, "reset_secret");
+    return AsyncHelper.callAsync(api, emptyParam(), option)
+        .thenApply(
+            result -> FlattenResultBase.fromDashScopeResult(result, WebhookSecretReset.class));
+  }
+
+  public CompletableFuture<CursorPage<WebhookEvent>> listEventsAsync(String webhookId) {
+    return listEventsAsync(webhookId, WebhookEventListParam.builder().build());
+  }
+
+  public CompletableFuture<CursorPage<WebhookEvent>> listEventsAsync(
+      String webhookId, WebhookEventListParam param) {
+    if (isEmpty(webhookId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("webhookId is required!"));
+    }
+    if (param == null) {
+      return AsyncHelper.failedFuture(new InputRequiredException("param is required!"));
+    }
+    String query = param.toQueryString();
+    String path = StringUtils.format("%s/%s/events", RESOURCE_PATH, webhookId);
+    GeneralServiceOption option =
+        AgentStudioConstants.newServiceOption(
+            HttpMethod.GET, query.isEmpty() ? path : path + "?" + query, baseUrl);
+    return AsyncHelper.callAsync(api, emptyParam(), option)
+        .thenApply(
+            result -> {
+              Type type = new TypeToken<CursorPage<WebhookEvent>>() {}.getType();
+              CursorPage<WebhookEvent> page =
+                  FlattenResultBase.fromDashScopeResult(result, type);
+              page.setFetchNext(
+                  cursor ->
+                      listEventsAsync(
+                          webhookId,
+                          WebhookEventListParam.builder()
+                              .limit(param.getLimit())
+                              .page(cursor)
+                              .build()));
+              return page;
+            });
+  }
+
+  private CompletableFuture<WebhookEndpoint> endpointActionAsync(
+      String webhookId, String action) {
+    if (isEmpty(webhookId)) {
+      return AsyncHelper.failedFuture(new InputRequiredException("webhookId is required!"));
+    }
+    return AsyncHelper.callAsync(api, emptyParam(), actionOption(webhookId, action))
+        .thenApply(result -> FlattenResultBase.fromDashScopeResult(result, WebhookEndpoint.class));
+  }
+
+  private GeneralServiceOption actionOption(String webhookId, String action) {
+    return AgentStudioConstants.newServiceOption(
+        HttpMethod.POST,
+        StringUtils.format("%s/%s/%s", RESOURCE_PATH, webhookId, action),
+        baseUrl);
+  }
+
+  private GeneralGetParam emptyParam() {
+    return GeneralGetParam.builder().apiKey(apiKey).headers(new HashMap<>()).build();
+  }
+
+  private boolean isEmpty(String value) {
+    return value == null || value.isEmpty();
+  }
+}

--- a/src/main/java/com/alibaba/dashscope/agentstudio/resource/WebhookEndpoints.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/resource/WebhookEndpoints.java
@@ -19,6 +19,7 @@ import com.alibaba.dashscope.protocol.ConnectionOptions;
 import com.alibaba.dashscope.protocol.GeneralServiceOption;
 import com.alibaba.dashscope.protocol.HttpMethod;
 import com.alibaba.dashscope.utils.StringUtils;
+import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -59,8 +60,8 @@ public final class WebhookEndpoints {
     return AsyncHelper.joinAndUnwrap(updateAsync(webhookId, param));
   }
 
-  public void delete(String webhookId) {
-    AsyncHelper.joinAndUnwrap(deleteAsync(webhookId));
+  public JsonObject delete(String webhookId) {
+    return AsyncHelper.joinAndUnwrap(deleteAsync(webhookId));
   }
 
   public WebhookEndpoint enable(String webhookId) {
@@ -137,14 +138,15 @@ public final class WebhookEndpoints {
         .thenApply(result -> FlattenResultBase.fromDashScopeResult(result, WebhookEndpoint.class));
   }
 
-  public CompletableFuture<Void> deleteAsync(String webhookId) {
+  public CompletableFuture<JsonObject> deleteAsync(String webhookId) {
     if (isEmpty(webhookId)) {
       return AsyncHelper.failedFuture(new InputRequiredException("webhookId is required!"));
     }
     GeneralServiceOption option =
         AgentStudioConstants.newServiceOption(
             HttpMethod.DELETE, StringUtils.format("%s/%s", RESOURCE_PATH, webhookId), baseUrl);
-    return AsyncHelper.callAsync(api, emptyParam(), option).thenApply(result -> null);
+    return AsyncHelper.callAsync(api, emptyParam(), option)
+        .thenApply(result -> (JsonObject) result.getOutput());
   }
 
   public CompletableFuture<WebhookEndpoint> enableAsync(String webhookId) {

--- a/src/main/java/com/alibaba/dashscope/agentstudio/resource/WebhookEndpoints.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/resource/WebhookEndpoints.java
@@ -84,8 +84,7 @@ public final class WebhookEndpoints {
     return listEvents(webhookId, WebhookEventListParam.builder().build());
   }
 
-  public CursorPage<WebhookEvent> listEvents(
-      String webhookId, WebhookEventListParam param) {
+  public CursorPage<WebhookEvent> listEvents(String webhookId, WebhookEventListParam param) {
     return AsyncHelper.joinAndUnwrap(listEventsAsync(webhookId, param));
   }
 
@@ -119,8 +118,7 @@ public final class WebhookEndpoints {
         AgentStudioConstants.newServiceOption(HttpMethod.GET, RESOURCE_PATH, baseUrl);
     return AsyncHelper.callAsync(api, emptyParam(), option)
         .thenApply(
-            result ->
-                FlattenResultBase.fromDashScopeResult(result, WebhookEndpointList.class));
+            result -> FlattenResultBase.fromDashScopeResult(result, WebhookEndpointList.class));
   }
 
   public CompletableFuture<WebhookEndpoint> updateAsync(
@@ -197,8 +195,7 @@ public final class WebhookEndpoints {
         .thenApply(
             result -> {
               Type type = new TypeToken<CursorPage<WebhookEvent>>() {}.getType();
-              CursorPage<WebhookEvent> page =
-                  FlattenResultBase.fromDashScopeResult(result, type);
+              CursorPage<WebhookEvent> page = FlattenResultBase.fromDashScopeResult(result, type);
               page.setFetchNext(
                   cursor ->
                       listEventsAsync(
@@ -211,8 +208,7 @@ public final class WebhookEndpoints {
             });
   }
 
-  private CompletableFuture<WebhookEndpoint> endpointActionAsync(
-      String webhookId, String action) {
+  private CompletableFuture<WebhookEndpoint> endpointActionAsync(String webhookId, String action) {
     if (isEmpty(webhookId)) {
       return AsyncHelper.failedFuture(new InputRequiredException("webhookId is required!"));
     }
@@ -222,9 +218,7 @@ public final class WebhookEndpoints {
 
   private GeneralServiceOption actionOption(String webhookId, String action) {
     return AgentStudioConstants.newServiceOption(
-        HttpMethod.POST,
-        StringUtils.format("%s/%s/%s", RESOURCE_PATH, webhookId, action),
-        baseUrl);
+        HttpMethod.POST, StringUtils.format("%s/%s/%s", RESOURCE_PATH, webhookId, action), baseUrl);
   }
 
   private GeneralGetParam emptyParam() {

--- a/src/main/java/com/alibaba/dashscope/common/DashScopeResult.java
+++ b/src/main/java/com/alibaba/dashscope/common/DashScopeResult.java
@@ -87,7 +87,12 @@ public class DashScopeResult extends Result {
         this.output = response.getBinary();
       }
     } else {
-      this.output = parseJson(response.getMessage(), "Failed to parse HTTP response message");
+      if (Integer.valueOf(204).equals(response.getHttpStatusCode())) {
+        this.setStatusCode(response.getHttpStatusCode());
+        this.output = new JsonObject();
+      } else {
+        this.output = parseJson(response.getMessage(), "Failed to parse HTTP response message");
+      }
       this.event = response.getEvent();
     }
     return (T) this;

--- a/src/main/java/com/alibaba/dashscope/protocol/HalfDuplexRequest.java
+++ b/src/main/java/com/alibaba/dashscope/protocol/HalfDuplexRequest.java
@@ -120,7 +120,10 @@ public class HalfDuplexRequest {
           .parameters(param.getParameters())
           .httpMethod(getHttpMethod())
           .build();
-    } else if (getHttpMethod() == HttpMethod.POST || getHttpMethod() == HttpMethod.DELETE) {
+    } else if (
+        getHttpMethod() == HttpMethod.POST
+            || getHttpMethod() == HttpMethod.PUT
+            || getHttpMethod() == HttpMethod.DELETE) {
       JsonObject body = param.getHttpBody();
       if (isEncryptRequest() && body != null) { // we need to encrypt the input
         this.encryptionConfig = EncryptionUtils.generateEncryptionConfig(param.getApiKey());

--- a/src/main/java/com/alibaba/dashscope/protocol/HalfDuplexRequest.java
+++ b/src/main/java/com/alibaba/dashscope/protocol/HalfDuplexRequest.java
@@ -120,10 +120,9 @@ public class HalfDuplexRequest {
           .parameters(param.getParameters())
           .httpMethod(getHttpMethod())
           .build();
-    } else if (
-        getHttpMethod() == HttpMethod.POST
-            || getHttpMethod() == HttpMethod.PUT
-            || getHttpMethod() == HttpMethod.DELETE) {
+    } else if (getHttpMethod() == HttpMethod.POST
+        || getHttpMethod() == HttpMethod.PUT
+        || getHttpMethod() == HttpMethod.DELETE) {
       JsonObject body = param.getHttpBody();
       if (isEncryptRequest() && body != null) { // we need to encrypt the input
         this.encryptionConfig = EncryptionUtils.generateEncryptionConfig(param.getApiKey());

--- a/src/main/java/com/alibaba/dashscope/protocol/HttpMethod.java
+++ b/src/main/java/com/alibaba/dashscope/protocol/HttpMethod.java
@@ -2,8 +2,17 @@
 
 package com.alibaba.dashscope.protocol;
 
+/** HTTP methods supported by the SDK transport. */
 public enum HttpMethod {
+  /** Create or invoke an action. */
   POST,
+
+  /** Retrieve a resource. */
   GET,
+
+  /** Replace or update a resource. */
+  PUT,
+
+  /** Delete a resource. */
   DELETE;
 }

--- a/src/main/java/com/alibaba/dashscope/protocol/okhttp/OkHttpHttpClient.java
+++ b/src/main/java/com/alibaba/dashscope/protocol/okhttp/OkHttpHttpClient.java
@@ -210,6 +210,13 @@ public final class OkHttpHttpClient implements HalfDuplexClient {
         requestBuilder.post(RequestBody.create(MEDIA_TYPE_APPLICATION_JSON, ""));
       }
       request = requestBuilder.build();
+    } else if (req.getHttpMethod() == HttpMethod.PUT) {
+      Builder requestBuilder = new Request.Builder();
+      requestBuilder.url(req.getUrl()).headers(Headers.of(req.getHeaders()));
+      requestBuilder.put(
+          RequestBody.create(
+              MEDIA_TYPE_APPLICATION_JSON, req.getBody() == null ? "" : (String) req.getBody()));
+      request = requestBuilder.build();
     } else if (req.getHttpMethod() == HttpMethod.DELETE) {
       Builder requestBuilder = new Request.Builder();
       requestBuilder.url(req.getUrl()).headers(Headers.of(req.getHeaders()));


### PR DESCRIPTION
Adds Managed Agent Webhook endpoint CRUD, enable and disable, test, signing secret reset, and endpoint event query APIs. Includes 32 named event types and delivery response models. Validation: Java compilation passed.