### PR TITLE
fix(common): treat empty 2xx bodies as success instead of internal errors

### DIFF
--- a/src/main/java/com/alibaba/dashscope/common/DashScopeResult.java
+++ b/src/main/java/com/alibaba/dashscope/common/DashScopeResult.java
@@ -87,11 +87,16 @@ public class DashScopeResult extends Result {
         this.output = response.getBinary();
       }
     } else {
-      if (Integer.valueOf(204).equals(response.getHttpStatusCode())) {
+      if (response.getHttpStatusCode() != null) {
         this.setStatusCode(response.getHttpStatusCode());
+      }
+      String message = response.getMessage();
+      if (message == null || message.isEmpty()) {
+        // Non-2xx responses are raised as ApiException upstream, so an empty body here means a
+        // successful no-payload response such as 204, which Gson cannot parse.
         this.output = new JsonObject();
       } else {
-        this.output = parseJson(response.getMessage(), "Failed to parse HTTP response message");
+        this.output = parseJson(message, "Failed to parse HTTP response message");
       }
       this.event = response.getEvent();
     }

--- a/src/main/java/com/alibaba/dashscope/common/DashScopeResult.java
+++ b/src/main/java/com/alibaba/dashscope/common/DashScopeResult.java
@@ -52,10 +52,13 @@ public class DashScopeResult extends Result {
     } else {
       String message = response.getMessage();
       if (message == null || message.isEmpty()) {
-        log.warn(
-            "HTTP response message is null or empty, httpStatusCode: {}",
-            response.getHttpStatusCode());
-        setInternalError();
+        // Non-2xx responses are raised as ApiException upstream, so an empty body here means a
+        // successful no-payload response such as 204, which Gson cannot parse.
+        if (response.getHttpStatusCode() != null) {
+          this.setStatusCode(response.getHttpStatusCode());
+        }
+        this.setCode("");
+        this.setMessage("");
         return (T) this;
       }
       JsonObject jsonObject = parseJson(message, "Failed to parse HTTP response as JSON: {}");
@@ -117,10 +120,10 @@ public class DashScopeResult extends Result {
       }
       String encryptedMessage = response.getMessage();
       if (encryptedMessage == null || encryptedMessage.isEmpty()) {
-        log.warn(
-            "Encrypted HTTP response message is null or empty, httpStatusCode: {}",
-            response.getHttpStatusCode());
-        setInternalError();
+        // Non-2xx responses are raised as ApiException upstream, so an empty body here means a
+        // successful no-payload response such as 204, which Gson cannot parse.
+        this.setCode("");
+        this.setMessage("");
         return (T) this;
       }
       JsonObject jsonObject =

--- a/src/test/java/com/alibaba/dashscope/TestDashScopeResultEmptyBody.java
+++ b/src/test/java/com/alibaba/dashscope/TestDashScopeResultEmptyBody.java
@@ -1,0 +1,86 @@
+// Copyright (c) Alibaba, Inc. and its affiliates.
+
+package com.alibaba.dashscope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alibaba.dashscope.common.DashScopeResult;
+import com.alibaba.dashscope.common.PublicErrorDef;
+import com.alibaba.dashscope.protocol.NetworkResponse;
+import com.alibaba.dashscope.protocol.Protocol;
+import com.google.gson.JsonObject;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A successful HTTP response carrying no payload must not be reported as an internal error. Gson
+ * cannot parse an empty body, so {@code DashScopeResult} has to short-circuit it.
+ */
+public class TestDashScopeResultEmptyBody {
+
+  private DashScopeResult flattenResult(Integer statusCode, String message) throws Exception {
+    NetworkResponse response =
+        NetworkResponse.builder()
+            .headers(Collections.emptyMap())
+            .message(message)
+            .httpStatusCode(statusCode)
+            .build();
+    return new DashScopeResult().fromResponse(Protocol.HTTP, response, true);
+  }
+
+  private void assertEmptySuccess(DashScopeResult result, int expectedStatusCode) {
+    assertEquals(expectedStatusCode, result.getStatusCode());
+    assertTrue(result.getOutput() instanceof JsonObject);
+    assertEquals(0, ((JsonObject) result.getOutput()).size());
+    assertNotEquals(
+        PublicErrorDef.INTERNAL_ERROR.getStatusCode(),
+        result.getStatusCode(),
+        "empty body was misreported as an internal error");
+    assertNotEquals(PublicErrorDef.INTERNAL_ERROR.getErrorCode(), result.getCode());
+  }
+
+  @Test
+  public void testNoContentIsEmptyResult() throws Exception {
+    assertEmptySuccess(flattenResult(204, ""), 204);
+  }
+
+  @Test
+  public void testAcceptedWithEmptyBodyIsEmptyResult() throws Exception {
+    assertEmptySuccess(flattenResult(202, ""), 202);
+  }
+
+  @Test
+  public void testOkWithEmptyBodyIsEmptyResult() throws Exception {
+    assertEmptySuccess(flattenResult(200, ""), 200);
+  }
+
+  @Test
+  public void testNullMessageIsEmptyResult() throws Exception {
+    assertEmptySuccess(flattenResult(204, null), 204);
+  }
+
+  @Test
+  public void testMissingStatusCodeStillYieldsEmptyResult() throws Exception {
+    DashScopeResult result = flattenResult(null, "");
+    assertTrue(result.getOutput() instanceof JsonObject);
+    assertEquals(0, ((JsonObject) result.getOutput()).size());
+  }
+
+  @Test
+  public void testJsonBodyIsParsedAndCarriesStatusCode() throws Exception {
+    DashScopeResult result = flattenResult(200, "{\"id\":\"wh_123\",\"deleted\":true}");
+    assertEquals(200, result.getStatusCode());
+    JsonObject output = (JsonObject) result.getOutput();
+    assertEquals("wh_123", output.get("id").getAsString());
+    assertTrue(output.get("deleted").getAsBoolean());
+  }
+
+  @Test
+  public void testMalformedBodyIsStillAnInternalError() throws Exception {
+    DashScopeResult result = flattenResult(200, "not json at all");
+    assertEquals(PublicErrorDef.INTERNAL_ERROR.getStatusCode(), result.getStatusCode());
+    assertEquals(PublicErrorDef.INTERNAL_ERROR.getErrorCode(), result.getCode());
+  }
+}

--- a/src/test/java/com/alibaba/dashscope/TestDashScopeResultEmptyBody.java
+++ b/src/test/java/com/alibaba/dashscope/TestDashScopeResultEmptyBody.java
@@ -4,10 +4,13 @@ package com.alibaba.dashscope;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.alibaba.dashscope.common.DashScopeResult;
 import com.alibaba.dashscope.common.PublicErrorDef;
+import com.alibaba.dashscope.protocol.ApiServiceOption;
+import com.alibaba.dashscope.protocol.HalfDuplexRequest;
 import com.alibaba.dashscope.protocol.NetworkResponse;
 import com.alibaba.dashscope.protocol.Protocol;
 import com.google.gson.JsonObject;
@@ -66,6 +69,56 @@ public class TestDashScopeResultEmptyBody {
     DashScopeResult result = flattenResult(null, "");
     assertTrue(result.getOutput() instanceof JsonObject);
     assertEquals(0, ((JsonObject) result.getOutput()).size());
+  }
+
+  private DashScopeResult nonFlattenResult(Integer statusCode, String message) throws Exception {
+    NetworkResponse response =
+        NetworkResponse.builder()
+            .headers(Collections.emptyMap())
+            .message(message)
+            .httpStatusCode(statusCode)
+            .build();
+    return new DashScopeResult().fromResponse(Protocol.HTTP, response, false);
+  }
+
+  @Test
+  public void testNonFlattenNoContentIsEmptySuccess() throws Exception {
+    DashScopeResult result = nonFlattenResult(204, "");
+    assertEquals(204, result.getStatusCode());
+    assertEquals("", result.getCode());
+    assertEquals("", result.getMessage());
+    assertNull(result.getOutput());
+  }
+
+  @Test
+  public void testNonFlattenAcceptedWithEmptyBodyIsEmptySuccess() throws Exception {
+    DashScopeResult result = nonFlattenResult(202, null);
+    assertEquals(202, result.getStatusCode());
+    assertEquals("", result.getCode());
+    assertNull(result.getOutput());
+  }
+
+  private DashScopeResult encryptedResult(Integer statusCode, String message) throws Exception {
+    NetworkResponse response =
+        NetworkResponse.builder()
+            .headers(Collections.emptyMap())
+            .message(message)
+            .httpStatusCode(statusCode)
+            .build();
+    HalfDuplexRequest req =
+        new HalfDuplexRequest(
+            HalfDuplexTestParam.builder().model("qwen-turbo").enableEncrypt(true).build(),
+            ApiServiceOption.builder().build());
+    return new DashScopeResult().fromResponse(Protocol.HTTP, response, true, req);
+  }
+
+  @Test
+  public void testEncryptedRequestNoContentIsEmptySuccess() throws Exception {
+    DashScopeResult result = encryptedResult(204, "");
+    assertEquals(204, result.getStatusCode());
+    assertEquals("", result.getCode());
+    assertEquals("", result.getMessage());
+    assertNull(result.getOutput());
   }
 
   @Test


### PR DESCRIPTION
## Problem

Successful HTTP responses with an empty body (e.g. `204 No Content`) were misreported as `500 InternalServerError`: the empty string fell through to Gson parsing, which throws on `""`, and the exception was swallowed into `setInternalError()`.

This affected every `DashScopeResult.fromResponse` path:

1. **Flatten path** — keyed an earlier fix on HTTP 204 only, which still left `200`/`202`/`205` with empty bodies broken, and `setStatusCode` was only applied in the 204 branch so `getStatusCode()` returned `null` for every normal response.
2. **Non-flatten path** — empty body still hit `log.warn` + `setInternalError()`. Dormant today (`getIsFlatten()` is hardcoded `true`), but the same bug would resurface for any `ServiceOption` returning `false`.
3. **Encrypted-response path** — same `log.warn` + `setInternalError()` pattern for empty bodies on encrypt-enabled requests.

Since `OkHttpHttpClient.send()` raises `ApiException` for all non-2xx responses, an empty body that reaches `fromResponse` is always a successful no-payload response.

## Fix

Key on **empty body** instead of status code, in all three paths:

- **Flatten path**: empty body → `output = new JsonObject()`, and `setStatusCode` hoisted out of the conditional so the real HTTP status is carried for every response.
- **Non-flatten path**: empty body → real HTTP `statusCode`, `code`/`message` normalized to `""` (matching `populateFromHttpJson` invariants); `output` stays `null` (legitimate in this schema).
- **Encrypted path**: `statusCode` was already set before the empty check; only `code`/`message` normalization added.

## Tests

New `TestDashScopeResultEmptyBody` (10 cases) pins the regression:

- flatten: 204 / 200-empty / 202-empty / null message → `{}` + correct status code
- flatten: missing status code still yields empty result
- flatten: JSON body parsed and carries status code; malformed body still reports InternalServerError
- non-flatten: 204 + empty and 202 + null → empty success, no fake 500
- encrypted: 204 on encrypt-enabled request → empty success with status code

```
Tests run: 19, Failures: 0, Errors: 0 (incl. TestHalfDuplexHttpApi)
google-java-format: clean
```