### PR TITLE
feat(agentstudio): support deployment environment variables

### DIFF
--- a/src/main/java/com/alibaba/dashscope/agentstudio/model/Deployment.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/model/Deployment.java
@@ -42,6 +42,9 @@ public class Deployment extends FlattenResultBase {
   @SerializedName("vault_ids")
   private List<String> vaultIds;
 
+  @SerializedName("environment_variables")
+  private Map<String, String> environmentVariables;
+
   @SerializedName("metadata")
   private Map<String, String> metadata;
 

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
@@ -64,7 +64,8 @@ public class DeploymentCreateParam extends FlattenHalfDuplexParamBase {
     }
     if (environmentVariables != null) {
       body.add(
-          "environment_variables", JsonUtils.toJsonElement(new LinkedHashMap<>(environmentVariables)));
+          "environment_variables",
+          JsonUtils.toJsonElement(new LinkedHashMap<>(environmentVariables)));
     }
     if (metadata != null) {
       body.add("metadata", JsonUtils.toJsonElement(new LinkedHashMap<>(metadata)));

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentCreateParam.java
@@ -26,6 +26,7 @@ public class DeploymentCreateParam extends FlattenHalfDuplexParamBase {
   @NonNull private List<JsonObject> initialEvents;
   @Default private List<DeploymentResourceParam> resources = null;
   @Default private List<String> vaultIds = null;
+  @Default private Map<String, String> environmentVariables = null;
   @Default private Map<String, String> metadata = null;
 
   @Override
@@ -60,6 +61,10 @@ public class DeploymentCreateParam extends FlattenHalfDuplexParamBase {
         vaultItems.add(vaultId);
       }
       body.add("vault_ids", vaultItems);
+    }
+    if (environmentVariables != null) {
+      body.add(
+          "environment_variables", JsonUtils.toJsonElement(new LinkedHashMap<>(environmentVariables)));
     }
     if (metadata != null) {
       body.add("metadata", JsonUtils.toJsonElement(new LinkedHashMap<>(metadata)));

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
@@ -28,6 +28,7 @@ public class DeploymentUpdateParam extends FlattenHalfDuplexParamBase {
   @Default private List<JsonObject> initialEvents = null;
   @Default private List<DeploymentResourceParam> resources = null;
   @Default private List<String> vaultIds = null;
+  @Default private Map<String, String> environmentVariables = null;
   @Default private Map<String, String> metadata = null;
 
   @Override
@@ -83,6 +84,10 @@ public class DeploymentUpdateParam extends FlattenHalfDuplexParamBase {
         vaultItems.add(vaultId);
       }
       body.add("vault_ids", vaultItems);
+    }
+    if (environmentVariables != null) {
+      body.add(
+          "environment_variables", JsonUtils.toJsonElement(new LinkedHashMap<>(environmentVariables)));
     }
     if (metadata != null) {
       body.add("metadata", JsonUtils.toJsonElement(new LinkedHashMap<>(metadata)));

--- a/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
+++ b/src/main/java/com/alibaba/dashscope/agentstudio/param/DeploymentUpdateParam.java
@@ -87,7 +87,8 @@ public class DeploymentUpdateParam extends FlattenHalfDuplexParamBase {
     }
     if (environmentVariables != null) {
       body.add(
-          "environment_variables", JsonUtils.toJsonElement(new LinkedHashMap<>(environmentVariables)));
+          "environment_variables",
+          JsonUtils.toJsonElement(new LinkedHashMap<>(environmentVariables)));
     }
     if (metadata != null) {
       body.add("metadata", JsonUtils.toJsonElement(new LinkedHashMap<>(metadata)));

--- a/src/test/java/com/alibaba/dashscope/TestAgentStudioDeployments.java
+++ b/src/test/java/com/alibaba/dashscope/TestAgentStudioDeployments.java
@@ -81,6 +81,8 @@ public class TestAgentStudioDeployments {
                                 .mountPath("/mnt/data")
                                 .build()))
                     .vaultIds(Collections.singletonList("vault_01"))
+                    .environmentVariables(
+                        Collections.singletonMap("API_BASE_URL", "https://example.test"))
                     .metadata(Collections.singletonMap("biz", "summary"))
                     .build());
 
@@ -93,6 +95,9 @@ public class TestAgentStudioDeployments {
     assertEquals(
         "message",
         body.getAsJsonArray("initial_events").get(0).getAsJsonObject().get("type").getAsString());
+    assertEquals(
+        "https://example.test",
+        body.getAsJsonObject("environment_variables").get("API_BASE_URL").getAsString());
     assertEquals("summary", body.getAsJsonObject("metadata").get("biz").getAsString());
 
     assertEquals("depl_01", deployment.getId());
@@ -101,6 +106,7 @@ public class TestAgentStudioDeployments {
     assertEquals("Asia/Shanghai", deployment.getSchedule().getTimezone());
     assertEquals("file_01", deployment.getResources().get(0).getFileId());
     assertEquals("RUN_FAILED", deployment.getPausedReason().getError().getCode());
+    assertEquals("https://example.test", deployment.getEnvironmentVariables().get("API_BASE_URL"));
     assertEquals("summary", deployment.getMetadata().get("biz"));
     assertEquals("req-depl-01", deployment.getRequestId());
   }
@@ -113,6 +119,7 @@ public class TestAgentStudioDeployments {
             .clearEnvironment(true)
             .clearSchedule(true)
             .resources(Collections.emptyList())
+            .environmentVariables(Collections.emptyMap())
             .metadata(Collections.emptyMap())
             .build();
     assertTrue(updateParam.getClearEnvironment());
@@ -130,6 +137,7 @@ public class TestAgentStudioDeployments {
     assertTrue(body.has("schedule"), body.toString());
     assertTrue(body.get("schedule").isJsonNull());
     assertEquals(0, body.getAsJsonArray("resources").size());
+    assertEquals(0, body.getAsJsonObject("environment_variables").size());
     assertEquals(0, body.getAsJsonObject("metadata").size());
   }
 

--- a/src/test/resources/agentstudio.json
+++ b/src/test/resources/agentstudio.json
@@ -338,6 +338,7 @@
       {"type": "file", "file_id": "file_01", "mount_path": "/mnt/data"}
     ],
     "vault_ids": ["vault_01"],
+    "environment_variables": {"API_BASE_URL": "https://example.test"},
     "metadata": {"biz": "summary"},
     "status": "paused",
     "paused_reason": {


### PR DESCRIPTION
## Summary

Deployment 的 create / update 支持 `environment_variables`，响应模型回显该字段。用于给部署运行时注入环境变量：deployment run 创建 session 时由服务端透传，最终注入沙箱运行时。

契约与 session 侧一致：
- `Map<String, String>`，键值均为字符串
- update 为整体覆盖语义：传空 map 清空，不传不修改
- 不需要 `clearXxx` 开关（与 `metadata` 一致）

## Changes

- `model/Deployment.java`：新增 `environment_variables` 用于回显
- `param/DeploymentCreateParam.java`：新增字段并写入请求体
- `param/DeploymentUpdateParam.java`：新增字段并写入请求体；序列化沿用 `metadata` 的 `LinkedHashMap` 拷贝写法，保证空 map 序列化为 `{}`
- `TestAgentStudioDeployments.java` / `agentstudio.json`：补测试断言与 fixture

## Test plan

- [x] `mvn test -Dtest=TestAgentStudioDeployments` —— 5 个用例通过
- [x] create 用例断言字段写入请求体，且响应模型能回显
- [x] update 用例断言传空 map 时序列化为空对象（清空语义）
- [x] google-java-format 校验通过